### PR TITLE
Implement Ollama integration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,39 @@ This project is in early development.
 
 - Node.js >= 20.0.0
 - pnpm >= 9.0.0
+- [Ollama](https://ollama.ai/) (for LLM features)
+
+### Ollama Installation
+
+This application uses Ollama for local LLM communication.
+
+**macOS:**
+```bash
+brew install ollama
+```
+
+**Linux:**
+```bash
+curl -fsSL https://ollama.ai/install.sh | sh
+```
+
+**Start the Ollama server:**
+```bash
+ollama serve
+```
+
+**Pull the default model:**
+```bash
+ollama pull qwen2.5-coder:7b
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MUMBL_OLLAMA_URL` | `http://localhost:11434` | Ollama server base URL |
+| `MUMBL_OLLAMA_MODEL` | `qwen2.5-coder:7b` | Default model to use |
+| `MUMBL_OLLAMA_TIMEOUT` | `30000` | Connection timeout (ms) |
 
 ### Setup
 

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,12 @@
       },
       "suspicious": {
         "noExplicitAny": "warn"
+      },
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
+      "performance": {
+        "noDelete": "off"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "better-sqlite3": "^12.6.2",
     "ink": "^6.6.0",
+    "ollama": "^0.6.3",
     "react": "^19.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       ink:
         specifier: ^6.6.0
         version: 6.6.0(@types/react@19.2.9)(react@19.2.4)
+      ollama:
+        specifier: ^0.6.3
+        version: 0.6.3
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1226,6 +1229,9 @@ packages:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1573,6 +1579,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2637,6 +2646,10 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -2995,6 +3008,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  whatwg-fetch@3.6.20: {}
 
   which@2.0.2:
     dependencies:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { render } from 'ink';
 import React from 'react';
 import { closeDatabase, getDatabase } from './infrastructure/database/client.js';
 import { EntryService } from './services/entry-service.js';
+import { OllamaService } from './services/ollama-service.js';
 import { App } from './ui/App.js';
 import { ServiceProvider } from './ui/context/ServiceContext.js';
 
@@ -19,9 +20,10 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
 
   const db = getDatabase();
   const entryService = new EntryService(db);
+  const ollamaService = new OllamaService();
 
   const instance = render(
-    <ServiceProvider entryService={entryService}>
+    <ServiceProvider entryService={entryService} ollamaService={ollamaService}>
       <App />
     </ServiceProvider>,
   );

--- a/src/infrastructure/errors/ollama-errors.ts
+++ b/src/infrastructure/errors/ollama-errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Base error class for Ollama-related errors
+ */
+export class OllamaError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'OllamaError';
+  }
+}
+
+/**
+ * Thrown when Ollama server is not available
+ */
+export class OllamaConnectionError extends OllamaError {
+  constructor(
+    public readonly baseUrl: string,
+    cause?: Error,
+  ) {
+    super(`Cannot connect to Ollama at ${baseUrl}`, cause);
+    this.name = 'OllamaConnectionError';
+  }
+}
+
+/**
+ * Thrown when requested model is not available
+ */
+export class OllamaModelNotFoundError extends OllamaError {
+  constructor(public readonly model: string) {
+    super(`Model not available: ${model}`);
+    this.name = 'OllamaModelNotFoundError';
+  }
+}
+
+/**
+ * Thrown when Ollama API request fails
+ */
+export class OllamaApiError extends OllamaError {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    cause?: Error,
+  ) {
+    super(message, cause);
+    this.name = 'OllamaApiError';
+  }
+}

--- a/src/infrastructure/ollama/client.test.ts
+++ b/src/infrastructure/ollama/client.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OllamaConnectionError } from '../errors/ollama-errors.js';
+import {
+  checkOllamaHealth,
+  getOllamaClient,
+  getOllamaClientConfig,
+  initializeOllamaClient,
+  isModelAvailable,
+  listModels,
+  resetOllamaClient,
+} from './client.js';
+
+// Mock the ollama package
+vi.mock('ollama', () => ({
+  Ollama: vi.fn().mockImplementation(() => ({
+    list: vi.fn().mockResolvedValue({
+      models: [
+        {
+          name: 'qwen2.5-coder:7b',
+          modified_at: '2024-01-15T10:30:00Z',
+          size: 4500000000,
+          digest: 'abc123',
+          details: {
+            format: 'gguf',
+            family: 'qwen2',
+            parameter_size: '7B',
+            quantization_level: 'Q4_K_M',
+          },
+        },
+        {
+          name: 'llama2:latest',
+          modified_at: '2024-01-10T08:00:00Z',
+          size: 3800000000,
+          digest: 'def456',
+        },
+      ],
+    }),
+  })),
+}));
+
+describe('Ollama Client', () => {
+  beforeEach(() => {
+    resetOllamaClient();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetOllamaClient();
+  });
+
+  describe('initializeOllamaClient', () => {
+    it('should create a new Ollama client', async () => {
+      const { Ollama } = await import('ollama');
+
+      initializeOllamaClient();
+
+      expect(Ollama).toHaveBeenCalledWith({
+        host: 'http://localhost:11434',
+      });
+    });
+
+    it('should accept custom configuration', async () => {
+      const { Ollama } = await import('ollama');
+
+      initializeOllamaClient({ baseUrl: 'http://custom:8080' });
+
+      expect(Ollama).toHaveBeenCalledWith({
+        host: 'http://custom:8080',
+      });
+    });
+  });
+
+  describe('getOllamaClient', () => {
+    it('should return singleton instance', () => {
+      const client1 = getOllamaClient();
+      const client2 = getOllamaClient();
+
+      expect(client1).toBe(client2);
+    });
+  });
+
+  describe('getOllamaClientConfig', () => {
+    it('should return default config when not initialized', () => {
+      const config = getOllamaClientConfig();
+
+      expect(config.baseUrl).toBe('http://localhost:11434');
+      expect(config.defaultModel).toBe('qwen2.5-coder:7b');
+    });
+
+    it('should return custom config after initialization', () => {
+      initializeOllamaClient({
+        baseUrl: 'http://remote:11434',
+        defaultModel: 'llama2:latest',
+      });
+
+      const config = getOllamaClientConfig();
+
+      expect(config.baseUrl).toBe('http://remote:11434');
+      expect(config.defaultModel).toBe('llama2:latest');
+    });
+  });
+
+  describe('checkOllamaHealth', () => {
+    it('should return connected status when Ollama is available', async () => {
+      const health = await checkOllamaHealth();
+
+      expect(health.isConnected).toBe(true);
+      expect(health.baseUrl).toBe('http://localhost:11434');
+      expect(health.error).toBeUndefined();
+    });
+
+    it('should return disconnected status when Ollama is unavailable', async () => {
+      const { Ollama } = await import('ollama');
+      vi.mocked(Ollama).mockImplementationOnce(
+        () =>
+          ({
+            list: vi.fn().mockRejectedValue(new Error('Connection refused')),
+          }) as ReturnType<typeof Ollama>,
+      );
+
+      resetOllamaClient();
+      const health = await checkOllamaHealth();
+
+      expect(health.isConnected).toBe(false);
+      expect(health.error).toContain('Connection refused');
+    });
+  });
+
+  describe('listModels', () => {
+    it('should return list of models with correct properties', async () => {
+      const models = await listModels();
+
+      expect(models).toHaveLength(2);
+      expect(models[0]).toMatchObject({
+        name: 'qwen2.5-coder:7b',
+        size: 4500000000,
+        digest: 'abc123',
+      });
+      expect(models[0]?.details).toMatchObject({
+        format: 'gguf',
+        family: 'qwen2',
+        parameterSize: '7B',
+        quantizationLevel: 'Q4_K_M',
+      });
+    });
+
+    it('should handle models without details', async () => {
+      const models = await listModels();
+
+      expect(models[1]?.details).toBeUndefined();
+    });
+
+    it('should throw OllamaConnectionError when connection fails', async () => {
+      const { Ollama } = await import('ollama');
+      vi.mocked(Ollama).mockImplementationOnce(
+        () =>
+          ({
+            list: vi.fn().mockRejectedValue(new Error('Connection refused')),
+          }) as ReturnType<typeof Ollama>,
+      );
+
+      resetOllamaClient();
+
+      await expect(listModels()).rejects.toThrow(OllamaConnectionError);
+    });
+  });
+
+  describe('isModelAvailable', () => {
+    it('should return true for available model (exact match)', async () => {
+      const available = await isModelAvailable('qwen2.5-coder:7b');
+
+      expect(available).toBe(true);
+    });
+
+    it('should return true for default model when no argument', async () => {
+      const available = await isModelAvailable();
+
+      expect(available).toBe(true);
+    });
+
+    it('should return false for unavailable model', async () => {
+      const available = await isModelAvailable('nonexistent:model');
+
+      expect(available).toBe(false);
+    });
+
+    it('should return false when connection fails', async () => {
+      const { Ollama } = await import('ollama');
+      vi.mocked(Ollama).mockImplementationOnce(
+        () =>
+          ({
+            list: vi.fn().mockRejectedValue(new Error('Connection refused')),
+          }) as ReturnType<typeof Ollama>,
+      );
+
+      resetOllamaClient();
+      const available = await isModelAvailable('qwen2.5-coder:7b');
+
+      expect(available).toBe(false);
+    });
+  });
+
+  describe('resetOllamaClient', () => {
+    it('should reset client and config', () => {
+      initializeOllamaClient({ baseUrl: 'http://custom:8080' });
+      const configBefore = getOllamaClientConfig();
+      expect(configBefore.baseUrl).toBe('http://custom:8080');
+
+      resetOllamaClient();
+
+      const configAfter = getOllamaClientConfig();
+      expect(configAfter.baseUrl).toBe('http://localhost:11434');
+    });
+  });
+});

--- a/src/infrastructure/ollama/client.ts
+++ b/src/infrastructure/ollama/client.ts
@@ -1,0 +1,119 @@
+import { Ollama } from 'ollama';
+import { OllamaConnectionError } from '../errors/ollama-errors.js';
+import { type OllamaConfig, getOllamaConfig } from './config.js';
+import type { OllamaHealthStatus, OllamaModel } from './types.js';
+
+/**
+ * Singleton Ollama client instance
+ */
+let ollamaInstance: Ollama | null = null;
+let currentConfig: OllamaConfig | null = null;
+
+/**
+ * Initialize Ollama client with configuration
+ */
+export function initializeOllamaClient(config?: Partial<OllamaConfig>): Ollama {
+  const finalConfig = { ...getOllamaConfig(), ...config };
+
+  ollamaInstance = new Ollama({
+    host: finalConfig.baseUrl,
+  });
+
+  currentConfig = finalConfig;
+  return ollamaInstance;
+}
+
+/**
+ * Get singleton Ollama client instance
+ */
+export function getOllamaClient(): Ollama {
+  if (!ollamaInstance) {
+    ollamaInstance = initializeOllamaClient();
+  }
+  return ollamaInstance;
+}
+
+/**
+ * Get current Ollama configuration
+ */
+export function getOllamaClientConfig(): OllamaConfig {
+  if (!currentConfig) {
+    currentConfig = getOllamaConfig();
+  }
+  return currentConfig;
+}
+
+/**
+ * Check Ollama server health and connectivity
+ */
+export async function checkOllamaHealth(): Promise<OllamaHealthStatus> {
+  const config = getOllamaClientConfig();
+
+  try {
+    const client = getOllamaClient();
+    // Use list() as a health check - it's lightweight and confirms API is working
+    await client.list();
+
+    return {
+      isConnected: true,
+      baseUrl: config.baseUrl,
+    };
+  } catch (error) {
+    return {
+      isConnected: false,
+      baseUrl: config.baseUrl,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * List all available models
+ */
+export async function listModels(): Promise<OllamaModel[]> {
+  const client = getOllamaClient();
+  const config = getOllamaClientConfig();
+
+  try {
+    const response = await client.list();
+    return response.models.map((model) => ({
+      name: model.name,
+      modifiedAt: new Date(model.modified_at),
+      size: model.size,
+      digest: model.digest,
+      details: model.details
+        ? {
+            format: model.details.format,
+            family: model.details.family,
+            parameterSize: model.details.parameter_size,
+            quantizationLevel: model.details.quantization_level,
+          }
+        : undefined,
+    }));
+  } catch (error) {
+    throw new OllamaConnectionError(config.baseUrl, error instanceof Error ? error : undefined);
+  }
+}
+
+/**
+ * Check if specific model is available
+ */
+export async function isModelAvailable(modelName?: string): Promise<boolean> {
+  const config = getOllamaClientConfig();
+  const targetModel = modelName ?? config.defaultModel;
+
+  try {
+    const models = await listModels();
+    return models.some((m) => m.name === targetModel || m.name.startsWith(`${targetModel}:`));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reset Ollama client (for testing)
+ */
+export function resetOllamaClient(): void {
+  ollamaInstance = null;
+  currentConfig = null;
+}

--- a/src/infrastructure/ollama/config.test.ts
+++ b/src/infrastructure/ollama/config.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MODEL,
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_TIMEOUT,
+  getOllamaConfig,
+} from './config.js';
+
+describe('Ollama Config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('default values', () => {
+    it('should have correct default base URL', () => {
+      expect(DEFAULT_OLLAMA_BASE_URL).toBe('http://localhost:11434');
+    });
+
+    it('should have correct default model', () => {
+      expect(DEFAULT_MODEL).toBe('qwen2.5-coder:7b');
+    });
+
+    it('should have correct default timeout', () => {
+      expect(DEFAULT_TIMEOUT).toBe(30000);
+    });
+  });
+
+  describe('getOllamaConfig', () => {
+    it('should return default values when no env vars are set', () => {
+      delete process.env.MUMBL_OLLAMA_URL;
+      delete process.env.MUMBL_OLLAMA_MODEL;
+      delete process.env.MUMBL_OLLAMA_TIMEOUT;
+
+      const config = getOllamaConfig();
+
+      expect(config.baseUrl).toBe(DEFAULT_OLLAMA_BASE_URL);
+      expect(config.defaultModel).toBe(DEFAULT_MODEL);
+      expect(config.timeout).toBe(DEFAULT_TIMEOUT);
+    });
+
+    it('should use MUMBL_OLLAMA_URL when set', () => {
+      process.env.MUMBL_OLLAMA_URL = 'http://custom:8080';
+
+      const config = getOllamaConfig();
+
+      expect(config.baseUrl).toBe('http://custom:8080');
+    });
+
+    it('should use MUMBL_OLLAMA_MODEL when set', () => {
+      process.env.MUMBL_OLLAMA_MODEL = 'llama2:latest';
+
+      const config = getOllamaConfig();
+
+      expect(config.defaultModel).toBe('llama2:latest');
+    });
+
+    it('should use MUMBL_OLLAMA_TIMEOUT when set', () => {
+      process.env.MUMBL_OLLAMA_TIMEOUT = '60000';
+
+      const config = getOllamaConfig();
+
+      expect(config.timeout).toBe(60000);
+    });
+
+    it('should handle all env vars set together', () => {
+      process.env.MUMBL_OLLAMA_URL = 'http://remote:11434';
+      process.env.MUMBL_OLLAMA_MODEL = 'codellama:13b';
+      process.env.MUMBL_OLLAMA_TIMEOUT = '45000';
+
+      const config = getOllamaConfig();
+
+      expect(config.baseUrl).toBe('http://remote:11434');
+      expect(config.defaultModel).toBe('codellama:13b');
+      expect(config.timeout).toBe(45000);
+    });
+  });
+});

--- a/src/infrastructure/ollama/config.ts
+++ b/src/infrastructure/ollama/config.ts
@@ -1,0 +1,36 @@
+/**
+ * Default Ollama server base URL
+ */
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
+/**
+ * Default model for LLM operations
+ */
+export const DEFAULT_MODEL = 'qwen2.5-coder:7b';
+
+/**
+ * Default connection timeout in milliseconds
+ */
+export const DEFAULT_TIMEOUT = 30000;
+
+/**
+ * Ollama configuration interface
+ */
+export interface OllamaConfig {
+  baseUrl: string;
+  defaultModel: string;
+  timeout: number;
+}
+
+/**
+ * Get Ollama configuration from environment variables or defaults
+ */
+export function getOllamaConfig(): OllamaConfig {
+  return {
+    baseUrl: process.env['MUMBL_OLLAMA_URL'] ?? DEFAULT_OLLAMA_BASE_URL,
+    defaultModel: process.env['MUMBL_OLLAMA_MODEL'] ?? DEFAULT_MODEL,
+    timeout: process.env['MUMBL_OLLAMA_TIMEOUT']
+      ? Number.parseInt(process.env['MUMBL_OLLAMA_TIMEOUT'], 10)
+      : DEFAULT_TIMEOUT,
+  };
+}

--- a/src/infrastructure/ollama/types.ts
+++ b/src/infrastructure/ollama/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Model details from Ollama
+ */
+export interface OllamaModelDetails {
+  format: string;
+  family: string;
+  parameterSize: string;
+  quantizationLevel: string;
+}
+
+/**
+ * Model information returned by Ollama
+ */
+export interface OllamaModel {
+  name: string;
+  modifiedAt: Date;
+  size: number;
+  digest: string;
+  details?: OllamaModelDetails;
+}
+
+/**
+ * Ollama health status
+ */
+export interface OllamaHealthStatus {
+  isConnected: boolean;
+  baseUrl: string;
+  error?: string;
+}
+
+/**
+ * Model availability result
+ */
+export interface ModelAvailabilityResult {
+  isAvailable: boolean;
+  model: string;
+  error?: string;
+}

--- a/src/services/ollama-service.test.ts
+++ b/src/services/ollama-service.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  OllamaConnectionError,
+  OllamaModelNotFoundError,
+} from '../infrastructure/errors/ollama-errors.js';
+import { OllamaService } from './ollama-service.js';
+
+// Mock the client module
+vi.mock('../infrastructure/ollama/client.js', () => ({
+  checkOllamaHealth: vi.fn(),
+  getOllamaClientConfig: vi.fn(),
+  isModelAvailable: vi.fn(),
+  listModels: vi.fn(),
+}));
+
+const mockConfig = {
+  baseUrl: 'http://localhost:11434',
+  defaultModel: 'qwen2.5-coder:7b',
+  timeout: 30000,
+};
+
+describe('OllamaService', () => {
+  let service: OllamaService;
+
+  beforeEach(async () => {
+    service = new OllamaService();
+    vi.clearAllMocks();
+
+    // Reset mock implementation for getOllamaClientConfig
+    const { getOllamaClientConfig } = await import('../infrastructure/ollama/client.js');
+    vi.mocked(getOllamaClientConfig).mockReturnValue(mockConfig);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('checkHealth', () => {
+    it('should return health status from client', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+
+      const health = await service.checkHealth();
+
+      expect(health.isConnected).toBe(true);
+      expect(health.baseUrl).toBe('http://localhost:11434');
+    });
+  });
+
+  describe('ensureConnected', () => {
+    it('should not throw when Ollama is connected', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+
+      await expect(service.ensureConnected()).resolves.not.toThrow();
+    });
+
+    it('should throw OllamaConnectionError when disconnected', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: false,
+        baseUrl: 'http://localhost:11434',
+        error: 'Connection refused',
+      });
+
+      await expect(service.ensureConnected()).rejects.toThrow(OllamaConnectionError);
+    });
+  });
+
+  describe('getAvailableModels', () => {
+    it('should return models when connected', async () => {
+      const { checkOllamaHealth, listModels } = await import(
+        '../infrastructure/ollama/client.js'
+      );
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+      vi.mocked(listModels).mockResolvedValue([
+        {
+          name: 'qwen2.5-coder:7b',
+          modifiedAt: new Date('2024-01-15'),
+          size: 4500000000,
+          digest: 'abc123',
+        },
+      ]);
+
+      const models = await service.getAvailableModels();
+
+      expect(models).toHaveLength(1);
+      expect(models[0]?.name).toBe('qwen2.5-coder:7b');
+    });
+
+    it('should throw when not connected', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: false,
+        baseUrl: 'http://localhost:11434',
+        error: 'Connection refused',
+      });
+
+      await expect(service.getAvailableModels()).rejects.toThrow(OllamaConnectionError);
+    });
+  });
+
+  describe('checkDefaultModel', () => {
+    it('should return available when model is installed', async () => {
+      const { checkOllamaHealth, isModelAvailable } = await import(
+        '../infrastructure/ollama/client.js'
+      );
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+      vi.mocked(isModelAvailable).mockResolvedValue(true);
+
+      const result = await service.checkDefaultModel();
+
+      expect(result.isAvailable).toBe(true);
+      expect(result.model).toBe('qwen2.5-coder:7b');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return unavailable when model is not installed', async () => {
+      const { checkOllamaHealth, isModelAvailable } = await import(
+        '../infrastructure/ollama/client.js'
+      );
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+      vi.mocked(isModelAvailable).mockResolvedValue(false);
+
+      const result = await service.checkDefaultModel();
+
+      expect(result.isAvailable).toBe(false);
+      expect(result.error).toContain('is not installed');
+    });
+
+    it('should return unavailable when not connected', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: false,
+        baseUrl: 'http://localhost:11434',
+        error: 'Connection refused',
+      });
+
+      const result = await service.checkDefaultModel();
+
+      expect(result.isAvailable).toBe(false);
+      expect(result.error).toContain('Cannot connect');
+    });
+  });
+
+  describe('ensureModelAvailable', () => {
+    it('should not throw when model is available', async () => {
+      const { checkOllamaHealth, isModelAvailable } = await import(
+        '../infrastructure/ollama/client.js'
+      );
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+      vi.mocked(isModelAvailable).mockResolvedValue(true);
+
+      await expect(service.ensureModelAvailable()).resolves.not.toThrow();
+    });
+
+    it('should throw OllamaModelNotFoundError when model not available', async () => {
+      const { checkOllamaHealth, isModelAvailable } = await import(
+        '../infrastructure/ollama/client.js'
+      );
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: true,
+        baseUrl: 'http://localhost:11434',
+      });
+      vi.mocked(isModelAvailable).mockResolvedValue(false);
+
+      await expect(service.ensureModelAvailable('missing-model')).rejects.toThrow(
+        OllamaModelNotFoundError,
+      );
+    });
+
+    it('should throw OllamaConnectionError when not connected', async () => {
+      const { checkOllamaHealth } = await import('../infrastructure/ollama/client.js');
+      vi.mocked(checkOllamaHealth).mockResolvedValue({
+        isConnected: false,
+        baseUrl: 'http://localhost:11434',
+        error: 'Connection refused',
+      });
+
+      await expect(service.ensureModelAvailable()).rejects.toThrow(OllamaConnectionError);
+    });
+  });
+
+  describe('getDefaultModel', () => {
+    it('should return configured default model', () => {
+      const model = service.getDefaultModel();
+
+      expect(model).toBe('qwen2.5-coder:7b');
+    });
+  });
+
+  describe('getBaseUrl', () => {
+    it('should return configured base URL', () => {
+      const url = service.getBaseUrl();
+
+      expect(url).toBe('http://localhost:11434');
+    });
+  });
+});

--- a/src/services/ollama-service.ts
+++ b/src/services/ollama-service.ts
@@ -1,0 +1,96 @@
+import {
+  OllamaConnectionError,
+  OllamaModelNotFoundError,
+} from '../infrastructure/errors/ollama-errors.js';
+import {
+  checkOllamaHealth,
+  getOllamaClientConfig,
+  isModelAvailable,
+  listModels,
+} from '../infrastructure/ollama/client.js';
+import type {
+  ModelAvailabilityResult,
+  OllamaHealthStatus,
+  OllamaModel,
+} from '../infrastructure/ollama/types.js';
+
+/**
+ * High-level Ollama service for LLM operations
+ */
+export class OllamaService {
+  /**
+   * Check if Ollama is available and healthy
+   */
+  async checkHealth(): Promise<OllamaHealthStatus> {
+    return checkOllamaHealth();
+  }
+
+  /**
+   * Ensure Ollama is connected, throwing if not
+   */
+  async ensureConnected(): Promise<void> {
+    const health = await this.checkHealth();
+    if (!health.isConnected) {
+      throw new OllamaConnectionError(health.baseUrl);
+    }
+  }
+
+  /**
+   * Get list of available models
+   */
+  async getAvailableModels(): Promise<OllamaModel[]> {
+    await this.ensureConnected();
+    return listModels();
+  }
+
+  /**
+   * Check if the default model is available
+   */
+  async checkDefaultModel(): Promise<ModelAvailabilityResult> {
+    const config = getOllamaClientConfig();
+    const health = await this.checkHealth();
+
+    if (!health.isConnected) {
+      return {
+        isAvailable: false,
+        model: config.defaultModel,
+        error: `Cannot connect to Ollama: ${health.error}`,
+      };
+    }
+
+    const available = await isModelAvailable();
+    return {
+      isAvailable: available,
+      model: config.defaultModel,
+      error: available ? undefined : `Model ${config.defaultModel} is not installed`,
+    };
+  }
+
+  /**
+   * Ensure model is available, throwing if not
+   */
+  async ensureModelAvailable(modelName?: string): Promise<void> {
+    await this.ensureConnected();
+    const config = getOllamaClientConfig();
+    const targetModel = modelName ?? config.defaultModel;
+
+    const available = await isModelAvailable(targetModel);
+    if (!available) {
+      throw new OllamaModelNotFoundError(targetModel);
+    }
+  }
+
+  /**
+   * Get the configured default model name
+   */
+  getDefaultModel(): string {
+    return getOllamaClientConfig().defaultModel;
+  }
+
+  /**
+   * Get the configured base URL
+   */
+  getBaseUrl(): string {
+    return getOllamaClientConfig().baseUrl;
+  }
+}

--- a/src/ui/context/ServiceContext.tsx
+++ b/src/ui/context/ServiceContext.tsx
@@ -1,8 +1,10 @@
 import React, { createContext, useContext } from 'react';
 import type { EntryService } from '../../services/entry-service.js';
+import type { OllamaService } from '../../services/ollama-service.js';
 
 interface ServiceContextValue {
   entryService: EntryService;
+  ollamaService: OllamaService;
 }
 
 export const ServiceContext = createContext<ServiceContextValue | null>(null);
@@ -17,9 +19,14 @@ export function useServices(): ServiceContextValue {
 
 interface ServiceProviderProps {
   entryService: EntryService;
+  ollamaService: OllamaService;
   children: React.ReactNode;
 }
 
-export function ServiceProvider({ entryService, children }: ServiceProviderProps) {
-  return <ServiceContext.Provider value={{ entryService }}>{children}</ServiceContext.Provider>;
+export function ServiceProvider({ entryService, ollamaService, children }: ServiceProviderProps) {
+  return (
+    <ServiceContext.Provider value={{ entryService, ollamaService }}>
+      {children}
+    </ServiceContext.Provider>
+  );
 }


### PR DESCRIPTION
## Summary

Implements issue #6 by setting up the Ollama client for local LLM communication with proper error handling.

- Ollama client library integration (ollama-js)
- Connection check and health validation
- Error handling for Ollama unavailability
- Model availability check
- Configuration for Ollama base URL
- Default model: `qwen2.5-coder:7b`

## Changes

- **package.json**: Add ollama-js package
- **src/infrastructure/ollama/config.ts**: Configuration with env var support
- **src/infrastructure/ollama/types.ts**: TypeScript interfaces
- **src/infrastructure/ollama/client.ts**: Singleton client with health check
- **src/infrastructure/errors/ollama-errors.ts**: Error class hierarchy
- **src/services/ollama-service.ts**: High-level service API
- **src/ui/context/ServiceContext.tsx**: Add OllamaService to context
- **src/index.tsx**: Initialize OllamaService
- **README.md**: Ollama installation instructions
- **biome.json**: Disable conflicting lint rules

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `MUMBL_OLLAMA_URL` | `http://localhost:11434` | Ollama server base URL |
| `MUMBL_OLLAMA_MODEL` | `qwen2.5-coder:7b` | Default model to use |
| `MUMBL_OLLAMA_TIMEOUT` | `30000` | Connection timeout (ms) |

## Test plan

- [x] pnpm type-check passes
- [x] pnpm lint passes
- [x] pnpm test:unit passes (125 tests)
- [x] pnpm build passes