### PR TITLE
Change entry list to chat-style layout

### DIFF
--- a/src/ui/components/entries/EntryListItem.tsx
+++ b/src/ui/components/entries/EntryListItem.tsx
@@ -51,7 +51,7 @@ export function EntryListItem({ entry, isSelected, maxWidth = 60, reaction }: En
       {/* Second line: reaction (if exists) */}
       {reaction && (
         <Box>
-          <Text>  </Text>
+          <Text>{'  '}</Text>
           <Text dimColor>{formatReactionDisplay(reaction)}</Text>
         </Box>
       )}


### PR DESCRIPTION
## Summary

エントリー一覧の表示形式をリストビューからチャット形式に変更する。

- タイムスタンプを右端に薄く表示
- リアクションをエントリーの下の行に表示
- リアクションタイプに応じたアイコン表示

Fixes #48

## Before
```
> [2:34 PM] First entry...       ·
  [1:15 PM] Another entry...
```

## After
```
> ugh meetings                              2:34 PM
  la di da di da...
> can't focus today                         1:15 PM
  ·
```

## Changes

- [EntryListItem.tsx](src/ui/components/entries/EntryListItem.tsx): レイアウトを2行構造に変更

## Test plan

- [x] pnpm type-check passes
- [x] pnpm lint passes
- [x] pnpm test:unit passes
- [ ] Manual verification of chat-style display