### PR TITLE
Fix timestamp alignment for full-width characters (#51)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "better-sqlite3": "^12.6.2",
     "ink": "^6.6.0",
     "ollama": "^0.6.3",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "string-width": "^8.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react:
         specifier: ^19.2.4
         version: 19.2.4
+      string-width:
+        specifier: ^8.1.1
+        version: 8.1.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -1508,8 +1511,8 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string-width@8.1.0:
-    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+  string-width@8.1.1:
+    resolution: {integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==}
     engines: {node: '>=20'}
 
   string_decoder@1.3.0:
@@ -2461,7 +2464,7 @@ snapshots:
   cli-truncate@5.1.1:
     dependencies:
       slice-ansi: 7.1.2
-      string-width: 8.1.0
+      string-width: 8.1.1
 
   cli-width@4.1.0: {}
 
@@ -2685,7 +2688,7 @@ snapshots:
       signal-exit: 3.0.7
       slice-ansi: 7.1.2
       stack-utils: 2.0.6
-      string-width: 8.1.0
+      string-width: 8.1.1
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
@@ -3049,7 +3052,7 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
-  string-width@8.1.0:
+  string-width@8.1.1:
     dependencies:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2

--- a/src/ui/components/entries/EntryListItem.tsx
+++ b/src/ui/components/entries/EntryListItem.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 import React from 'react';
 import type { JournalEntry, Reaction } from '../../../repositories/types.js';
 import { formatEntryTimestamp } from '../../utils/date-formatter.js';
-import { getPreviewLine } from '../../utils/text-truncate.js';
+import { getDisplayWidth, getPreviewLine } from '../../utils/text-truncate.js';
 
 interface EntryListItemProps {
   entry: JournalEntry;
@@ -33,8 +33,8 @@ export function EntryListItem({ entry, isSelected, maxWidth = 60, reaction }: En
   const contentWidth = Math.max(10, maxWidth - timestampWidth - 2); // 2 for cursor "> "
   const preview = getPreviewLine(entry.content, contentWidth);
 
-  // Calculate padding between content and timestamp
-  const paddingLength = Math.max(1, maxWidth - 2 - preview.length - timestamp.length);
+  // Calculate padding between content and timestamp using display width
+  const paddingLength = Math.max(1, maxWidth - 2 - getDisplayWidth(preview) - timestamp.length);
   const padding = ' '.repeat(paddingLength);
 
   return (

--- a/src/ui/utils/text-truncate.test.ts
+++ b/src/ui/utils/text-truncate.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { getFirstLine, getPreviewLine, truncateText } from './text-truncate.js';
+import { getDisplayWidth, getFirstLine, getPreviewLine, truncateText } from './text-truncate.js';
+
+describe('getDisplayWidth', () => {
+  it('should return correct width for ASCII characters', () => {
+    expect(getDisplayWidth('hello')).toBe(5);
+    expect(getDisplayWidth('Hello World')).toBe(11);
+  });
+
+  it('should return correct width for full-width characters', () => {
+    // Japanese characters are 2 columns each
+    expect(getDisplayWidth('こんにちは')).toBe(10);
+    expect(getDisplayWidth('日本語')).toBe(6);
+  });
+
+  it('should return correct width for mixed content', () => {
+    // "Hi " (3) + "日本" (4) = 7
+    expect(getDisplayWidth('Hi 日本')).toBe(7);
+    // "Hello" (5) + "こんにちは" (10) = 15
+    expect(getDisplayWidth('Helloこんにちは')).toBe(15);
+  });
+
+  it('should return 0 for empty string', () => {
+    expect(getDisplayWidth('')).toBe(0);
+  });
+});
 
 describe('truncateText', () => {
   it('should return empty string for maxWidth <= 0', () => {
@@ -24,6 +48,27 @@ describe('truncateText', () => {
 
   it('should handle empty string', () => {
     expect(truncateText('', 10)).toBe('');
+  });
+
+  it('should truncate full-width characters by display width', () => {
+    // "こんにちは" = 10 columns, truncate to 8 columns = "こんに" (6) + "..." (3) = 9 > 8
+    // So we need "こん" (4) + "..." (3) = 7, or fit within 8
+    // Actually: maxWidth 8, need 3 for ellipsis, so 5 columns for text
+    // "こん" = 4 columns, fits. "こんに" = 6 columns, doesn't fit.
+    expect(truncateText('こんにちは', 8)).toBe('こん...');
+  });
+
+  it('should not truncate full-width text that fits', () => {
+    // "日本語" = 6 columns
+    expect(truncateText('日本語', 10)).toBe('日本語');
+    expect(truncateText('日本語', 6)).toBe('日本語');
+  });
+
+  it('should handle mixed content truncation', () => {
+    // "Hello日本語" = 5 + 6 = 11 columns
+    // Truncate to 10: need 7 for content + 3 for "..."
+    // "Hello日" = 5 + 2 = 7 columns
+    expect(truncateText('Hello日本語', 10)).toBe('Hello日...');
   });
 });
 

--- a/src/ui/utils/text-truncate.ts
+++ b/src/ui/utils/text-truncate.ts
@@ -1,5 +1,15 @@
+import stringWidth from 'string-width';
+
 /**
- * Truncates text to fit within a given width
+ * Gets the display width of a string (full-width chars = 2, half-width = 1)
+ */
+export function getDisplayWidth(text: string): number {
+  return stringWidth(text);
+}
+
+/**
+ * Truncates text to fit within a given display width
+ * Accounts for full-width characters (Japanese, Chinese, etc.)
  * Adds ellipsis if truncated
  */
 export function truncateText(text: string, maxWidth: number): string {
@@ -7,15 +17,36 @@ export function truncateText(text: string, maxWidth: number): string {
     return '';
   }
 
-  if (text.length <= maxWidth) {
+  const textWidth = stringWidth(text);
+  if (textWidth <= maxWidth) {
     return text;
   }
 
   if (maxWidth <= 3) {
-    return text.slice(0, maxWidth);
+    return truncateToWidth(text, maxWidth);
   }
 
-  return `${text.slice(0, maxWidth - 3)}...`;
+  return `${truncateToWidth(text, maxWidth - 3)}...`;
+}
+
+/**
+ * Truncates text to fit within a given display width
+ * Returns the longest prefix that fits within maxWidth
+ */
+function truncateToWidth(text: string, maxWidth: number): string {
+  let currentWidth = 0;
+  let result = '';
+
+  for (const char of text) {
+    const charWidth = stringWidth(char);
+    if (currentWidth + charWidth > maxWidth) {
+      break;
+    }
+    currentWidth += charWidth;
+    result += char;
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #51 - Timestamp position misaligned for full-width characters (Japanese text).

- Add string-width library to calculate actual display width
- Update truncateText to use display width instead of character count
- Fix padding calculation in EntryListItem using display width

## Changes

- **package.json**: Add string-width dependency
- **src/ui/utils/text-truncate.ts**: Add getDisplayWidth function, update truncateText for display width
- **src/ui/components/entries/EntryListItem.tsx**: Use getDisplayWidth for padding calculation
- **src/ui/utils/text-truncate.test.ts**: Add tests for full-width character handling

## Test plan

- [x] All existing tests pass (334 tests)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual test with Japanese text entries to verify alignment