### PR TITLE
Implement scrollable entry list with viewport-aware rendering

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -5,6 +5,8 @@ import { useNavigation } from '../../context/NavigationContext.js';
 import { useEntries } from '../../hooks/useEntries.js';
 import { useKeyboardNavigation } from '../../hooks/useKeyboardNavigation.js';
 import { useReactions } from '../../hooks/useReactions.js';
+import { useScrollableList } from '../../hooks/useScrollableList.js';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { groupEntriesByDate } from '../../utils/date-formatter.js';
 import { EmptyState } from './EmptyState.js';
 import { EntryDetail } from './EntryDetail.js';
@@ -93,6 +95,30 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // Map flat list index to selected entry
   const selectedEntryId = entryItems[selectedIndex]?.entry?.id;
 
+  // Find the flatList index of the selected entry for scrolling
+  const selectedFlatIndex = useMemo(() => {
+    if (!selectedEntryId) return 0;
+    return flatList.findIndex((item) => item.type === 'entry' && item.entry.id === selectedEntryId);
+  }, [flatList, selectedEntryId]);
+
+  // Get terminal size for viewport calculation
+  const { rows: terminalRows } = useTerminalSize();
+
+  // Calculate viewport height: terminal rows - header (2 lines) - padding (2 lines) - footer reserve (3 lines)
+  const viewportHeight = Math.max(5, terminalRows - 7);
+
+  // Use scrollable list hook for scroll management
+  const { visibleStartIndex, visibleEndIndex, hasItemsAbove, hasItemsBelow } = useScrollableList({
+    totalItems: flatList.length,
+    selectedIndex: selectedFlatIndex,
+    viewportHeight,
+  });
+
+  // Slice the flatList for visible items
+  const visibleItems = useMemo(() => {
+    return flatList.slice(visibleStartIndex, visibleEndIndex + 1);
+  }, [flatList, visibleStartIndex, visibleEndIndex]);
+
   if (loading) {
     return (
       <Box padding={1}>
@@ -124,10 +150,17 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
           Journal Entries
         </Text>
         <Text dimColor> ({entries.length} total)</Text>
+        {(hasItemsAbove || hasItemsBelow) && (
+          <Text dimColor>
+            {' '}
+            {hasItemsAbove ? '▲' : ' '}
+            {hasItemsBelow ? '▼' : ' '}
+          </Text>
+        )}
       </Box>
 
-      <Box flexDirection="column">
-        {flatList.map((item) => {
+      <Box flexDirection="column" height={viewportHeight} overflow="hidden">
+        {visibleItems.map((item) => {
           if (item.type === 'header') {
             return (
               <EntryGroupHeader

--- a/src/ui/hooks/useScrollableList.test.tsx
+++ b/src/ui/hooks/useScrollableList.test.tsx
@@ -1,0 +1,106 @@
+import { Text } from 'ink';
+import { cleanup, render } from 'ink-testing-library';
+import React, { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useScrollableList } from './useScrollableList.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+interface TestComponentProps {
+  totalItems: number;
+  initialSelectedIndex: number;
+  viewportHeight: number;
+}
+
+function TestComponent({ totalItems, initialSelectedIndex, viewportHeight }: TestComponentProps) {
+  const [selectedIndex] = useState(initialSelectedIndex);
+  const result = useScrollableList({
+    totalItems,
+    selectedIndex,
+    viewportHeight,
+  });
+
+  return (
+    <Text>
+      offset:{result.scrollOffset} start:{result.visibleStartIndex} end:{result.visibleEndIndex}{' '}
+      above:{result.hasItemsAbove.toString()} below:{result.hasItemsBelow.toString()}
+    </Text>
+  );
+}
+
+describe('useScrollableList', () => {
+  it('should return initial scroll state at top', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={10} initialSelectedIndex={0} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('offset:0');
+    expect(lastFrame()).toContain('start:0');
+    expect(lastFrame()).toContain('end:4');
+    expect(lastFrame()).toContain('above:false');
+    expect(lastFrame()).toContain('below:true');
+  });
+
+  it('should scroll down when selected item is near bottom', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={10} initialSelectedIndex={6} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('offset:2');
+    expect(lastFrame()).toContain('start:2');
+    expect(lastFrame()).toContain('end:6');
+    expect(lastFrame()).toContain('above:true');
+    expect(lastFrame()).toContain('below:true');
+  });
+
+  it('should handle empty list', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={0} initialSelectedIndex={0} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('offset:0');
+    expect(lastFrame()).toContain('above:false');
+    expect(lastFrame()).toContain('below:false');
+  });
+
+  it('should handle list smaller than viewport', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={3} initialSelectedIndex={2} viewportHeight={10} />,
+    );
+
+    expect(lastFrame()).toContain('offset:0');
+    expect(lastFrame()).toContain('start:0');
+    expect(lastFrame()).toContain('end:2');
+    expect(lastFrame()).toContain('above:false');
+    expect(lastFrame()).toContain('below:false');
+  });
+
+  it('should show only hasItemsBelow when at top of long list', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={20} initialSelectedIndex={0} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('above:false');
+    expect(lastFrame()).toContain('below:true');
+  });
+
+  it('should show only hasItemsAbove when at bottom of long list', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={20} initialSelectedIndex={19} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('above:true');
+    expect(lastFrame()).toContain('below:false');
+  });
+
+  it('should show both indicators when in middle of long list', () => {
+    const { lastFrame } = render(
+      <TestComponent totalItems={20} initialSelectedIndex={10} viewportHeight={5} />,
+    );
+
+    expect(lastFrame()).toContain('above:true');
+    expect(lastFrame()).toContain('below:true');
+  });
+});

--- a/src/ui/hooks/useScrollableList.ts
+++ b/src/ui/hooks/useScrollableList.ts
@@ -1,0 +1,70 @@
+import { useRef } from 'react';
+
+export interface UseScrollableListOptions {
+  totalItems: number;
+  selectedIndex: number;
+  viewportHeight: number;
+  itemHeight?: number;
+}
+
+export interface UseScrollableListResult {
+  scrollOffset: number;
+  visibleStartIndex: number;
+  visibleEndIndex: number;
+  hasItemsAbove: boolean;
+  hasItemsBelow: boolean;
+}
+
+function calculateScrollOffset(
+  selectedIndex: number,
+  currentOffset: number,
+  visibleCount: number,
+  totalItems: number,
+): number {
+  if (totalItems === 0) {
+    return 0;
+  }
+
+  // If selected item is above visible area, scroll up
+  if (selectedIndex < currentOffset) {
+    return selectedIndex;
+  }
+
+  // If selected item is below visible area, scroll down
+  const visibleEndIndex = currentOffset + visibleCount - 1;
+  if (selectedIndex > visibleEndIndex) {
+    return selectedIndex - visibleCount + 1;
+  }
+
+  return currentOffset;
+}
+
+export function useScrollableList(options: UseScrollableListOptions): UseScrollableListResult {
+  const { totalItems, selectedIndex, viewportHeight, itemHeight = 1 } = options;
+  const scrollOffsetRef = useRef(0);
+
+  const visibleCount = Math.floor(viewportHeight / itemHeight);
+
+  // Calculate scroll offset synchronously on each render
+  scrollOffsetRef.current = calculateScrollOffset(
+    selectedIndex,
+    scrollOffsetRef.current,
+    visibleCount,
+    totalItems,
+  );
+
+  const scrollOffset = scrollOffsetRef.current;
+
+  const visibleStartIndex = scrollOffset;
+  const visibleEndIndex = Math.min(scrollOffset + visibleCount - 1, totalItems - 1);
+  const hasItemsAbove = scrollOffset > 0;
+  const hasItemsBelow = visibleEndIndex < totalItems - 1;
+
+  return {
+    scrollOffset,
+    visibleStartIndex,
+    visibleEndIndex,
+    hasItemsAbove,
+    hasItemsBelow,
+  };
+}

--- a/src/ui/hooks/useTerminalSize.ts
+++ b/src/ui/hooks/useTerminalSize.ts
@@ -1,0 +1,40 @@
+import { useStdout } from 'ink';
+import { useEffect, useState } from 'react';
+
+export interface TerminalSize {
+  columns: number;
+  rows: number;
+}
+
+const DEFAULT_SIZE: TerminalSize = {
+  columns: 80,
+  rows: 24,
+};
+
+export function useTerminalSize(): TerminalSize {
+  const { stdout } = useStdout();
+  const [size, setSize] = useState<TerminalSize>(() => ({
+    columns: stdout?.columns ?? DEFAULT_SIZE.columns,
+    rows: stdout?.rows ?? DEFAULT_SIZE.rows,
+  }));
+
+  useEffect(() => {
+    if (!stdout) return;
+
+    const handleResize = () => {
+      setSize({
+        columns: stdout.columns ?? DEFAULT_SIZE.columns,
+        rows: stdout.rows ?? DEFAULT_SIZE.rows,
+      });
+    };
+
+    stdout.on('resize', handleResize);
+    handleResize();
+
+    return () => {
+      stdout.off('resize', handleResize);
+    };
+  }, [stdout]);
+
+  return size;
+}


### PR DESCRIPTION
## Summary

Implements issue #50 - Entry list scrolling support to keep selected items visible.

- Add `useTerminalSize` hook to get terminal dimensions
- Add `useScrollableList` hook to manage scroll offset based on selection
- Modify `EntryList.tsx` to render only visible items and show scroll indicators (▲/▼)

## Changes

- **src/ui/hooks/useTerminalSize.ts**: New hook to track terminal size using Ink's `useStdout()`
- **src/ui/hooks/useScrollableList.ts**: New hook to calculate scroll offset and visible range
- **src/ui/hooks/useScrollableList.test.tsx**: Tests for scrollable list hook
- **src/ui/components/entries/EntryList.tsx**: Updated to use slice-based rendering with scroll indicators

## Test plan

- [x] All existing tests pass (334 tests)
- [x] New tests for `useScrollableList` hook
- [ ] Manual testing with long entry lists
- [ ] Verify scroll indicators appear when items are above/below viewport
- [ ] Verify j/k navigation scrolls to keep selected item visible

Fixes #50