### PR TITLE
Fix reactions overlapping with post content in Journal Entries view

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -107,11 +107,23 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // Calculate viewport height: terminal rows - header (2 lines) - padding (2 lines) - footer reserve (3 lines)
   const viewportHeight = Math.max(5, terminalRows - 7);
 
-  // Use scrollable list hook for scroll management
+  // Calculate item heights: entries with reactions = 2 lines, headers = 1 line, entries without reactions = 1 line
+  const itemHeights = useMemo(() => {
+    return flatList.map((item) => {
+      if (item.type === 'header') {
+        return 1;
+      }
+      // Entry with reaction takes 2 lines, without reaction takes 1 line
+      return reactions.has(item.entry.id) ? 2 : 1;
+    });
+  }, [flatList, reactions]);
+
+  // Use scrollable list hook for scroll management with variable item heights
   const { visibleStartIndex, visibleEndIndex, hasItemsAbove, hasItemsBelow } = useScrollableList({
     totalItems: flatList.length,
     selectedIndex: selectedFlatIndex,
     viewportHeight,
+    itemHeights,
   });
 
   // Slice the flatList for visible items

--- a/src/ui/hooks/useScrollableList.ts
+++ b/src/ui/hooks/useScrollableList.ts
@@ -4,6 +4,9 @@ export interface UseScrollableListOptions {
   totalItems: number;
   selectedIndex: number;
   viewportHeight: number;
+  /** Array of heights for each item. If provided, itemHeight is ignored. */
+  itemHeights?: number[];
+  /** Default height for all items when itemHeights is not provided */
   itemHeight?: number;
 }
 
@@ -13,6 +16,88 @@ export interface UseScrollableListResult {
   visibleEndIndex: number;
   hasItemsAbove: boolean;
   hasItemsBelow: boolean;
+}
+
+/**
+ * Find the start index that fits within viewport starting from a given scroll position
+ */
+function findVisibleRange(
+  itemHeights: number[],
+  scrollOffset: number,
+  viewportHeight: number,
+): { startIndex: number; endIndex: number } {
+  if (itemHeights.length === 0) {
+    return { startIndex: 0, endIndex: -1 };
+  }
+
+  // Find start index based on scroll offset
+  let startIndex = 0;
+
+  // Skip items above the scroll offset
+  for (let i = 0; i < scrollOffset && i < itemHeights.length; i++) {
+    startIndex = i + 1;
+  }
+
+  // Find end index that fits within viewport
+  let visibleHeight = 0;
+  let endIndex = startIndex;
+
+  for (let i = startIndex; i < itemHeights.length; i++) {
+    const height = itemHeights[i] ?? 1;
+    if (visibleHeight + height > viewportHeight) {
+      break;
+    }
+    visibleHeight += height;
+    endIndex = i;
+  }
+
+  return { startIndex, endIndex };
+}
+
+/**
+ * Calculate scroll offset to ensure selected item is visible
+ */
+function calculateScrollOffsetVariable(
+  selectedIndex: number,
+  currentOffset: number,
+  itemHeights: number[],
+  viewportHeight: number,
+): number {
+  if (itemHeights.length === 0) {
+    return 0;
+  }
+
+  // Clamp selected index
+  const clampedIndex = Math.max(0, Math.min(selectedIndex, itemHeights.length - 1));
+
+  // If selected item is above visible area, scroll up to show it
+  if (clampedIndex < currentOffset) {
+    return clampedIndex;
+  }
+
+  // Calculate visible range from current offset
+  const { endIndex } = findVisibleRange(itemHeights, currentOffset, viewportHeight);
+
+  // If selected item is below visible area, scroll down
+  if (clampedIndex > endIndex) {
+    // Find new offset that makes selected item visible at the bottom
+    const selectedHeight = itemHeights[clampedIndex] ?? 1;
+    let heightSum = selectedHeight;
+    let newOffset = clampedIndex;
+
+    for (let i = clampedIndex - 1; i >= 0; i--) {
+      const height = itemHeights[i] ?? 1;
+      if (heightSum + height > viewportHeight) {
+        break;
+      }
+      heightSum += height;
+      newOffset = i;
+    }
+
+    return newOffset;
+  }
+
+  return currentOffset;
 }
 
 function calculateScrollOffset(
@@ -40,9 +125,34 @@ function calculateScrollOffset(
 }
 
 export function useScrollableList(options: UseScrollableListOptions): UseScrollableListResult {
-  const { totalItems, selectedIndex, viewportHeight, itemHeight = 1 } = options;
+  const { totalItems, selectedIndex, viewportHeight, itemHeights, itemHeight = 1 } = options;
   const scrollOffsetRef = useRef(0);
 
+  // Use variable height calculation if itemHeights is provided
+  if (itemHeights && itemHeights.length > 0) {
+    scrollOffsetRef.current = calculateScrollOffsetVariable(
+      selectedIndex,
+      scrollOffsetRef.current,
+      itemHeights,
+      viewportHeight,
+    );
+
+    const scrollOffset = scrollOffsetRef.current;
+    const { startIndex, endIndex } = findVisibleRange(itemHeights, scrollOffset, viewportHeight);
+
+    const hasItemsAbove = scrollOffset > 0;
+    const hasItemsBelow = endIndex < itemHeights.length - 1;
+
+    return {
+      scrollOffset,
+      visibleStartIndex: startIndex,
+      visibleEndIndex: endIndex,
+      hasItemsAbove,
+      hasItemsBelow,
+    };
+  }
+
+  // Fall back to fixed height calculation
   const visibleCount = Math.floor(viewportHeight / itemHeight);
 
   // Calculate scroll offset synchronously on each render


### PR DESCRIPTION
## Summary

Fixes #61 - Reactions were displayed overlapping with post content in the Journal Entries list view.

- Add variable item height support to useScrollableList hook
- Calculate item heights based on whether entries have reactions (2 lines) or not (1 line)
- Entries with reactions now properly display on two separate lines

## Changes

- **src/ui/hooks/useScrollableList.ts**: Add `itemHeights` parameter and implement `findVisibleRange` / `calculateScrollOffsetVariable` functions for variable height items
- **src/ui/components/entries/EntryList.tsx**: Calculate and pass item heights based on reaction presence

## Test plan

- [x] All existing tests pass (`pnpm test:unit` - 446 tests)
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual verification: Run `pnpm dev`, create entries with reactions, verify reactions appear on separate lines
- [ ] Manual verification: Scroll through list to verify no overlap at any scroll position