### PR TITLE
Add reactions display to entry detail view

### DIFF
--- a/src/ui/components/entries/EntryDetail.tsx
+++ b/src/ui/components/entries/EntryDetail.tsx
@@ -1,7 +1,9 @@
 import { Box, Text, useInput } from 'ink';
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { JournalEntry } from '../../../repositories/types.js';
+import { useReactions } from '../../hooks/useReactions.js';
 import { formatFullDate } from '../../utils/date-formatter.js';
+import { formatReactionDisplay } from './EntryListItem.js';
 
 interface EntryDetailProps {
   entry: JournalEntry;
@@ -14,6 +16,10 @@ export function EntryDetail({ entry, onClose }: EntryDetailProps) {
       onClose();
     }
   });
+
+  const entryIds = useMemo(() => [entry.id], [entry.id]);
+  const { reactions } = useReactions(entryIds);
+  const reaction = reactions.get(entry.id);
 
   const metadata = entry.metadata;
   const hasTags = metadata.tags && metadata.tags.length > 0;
@@ -33,6 +39,12 @@ export function EntryDetail({ entry, onClose }: EntryDetailProps) {
         <Box marginBottom={1} flexDirection="column">
           <Text>{entry.content}</Text>
         </Box>
+
+        {reaction && (
+          <Box marginBottom={1}>
+            <Text dimColor>{formatReactionDisplay(reaction)}</Text>
+          </Box>
+        )}
 
         {hasMetadata && (
           <Box

--- a/src/ui/components/entries/EntryListItem.tsx
+++ b/src/ui/components/entries/EntryListItem.tsx
@@ -11,7 +11,7 @@ interface EntryListItemProps {
   reaction?: Reaction;
 }
 
-function formatReactionDisplay(reaction: Reaction): string {
+export function formatReactionDisplay(reaction: Reaction): string {
   switch (reaction.reactionType) {
     case 'read':
       return '·';


### PR DESCRIPTION
## Summary

Fixes #67 - Entry detail view now displays reactions, matching the behavior of the entry list view.

- Export `formatReactionDisplay` from `EntryListItem.tsx` for reuse
- Add `useReactions` hook to `EntryDetail.tsx` to fetch reactions
- Render reactions between content and metadata with `dimColor` styling

## Changes

- **src/ui/components/entries/EntryDetail.tsx**: Import `useReactions` hook and `formatReactionDisplay`, fetch and render reactions for the entry
- **src/ui/components/entries/EntryListItem.tsx**: Export `formatReactionDisplay` function for reuse

## Test plan

- [ ] `pnpm type-check` passes
- [ ] `pnpm lint` passes
- [ ] Create an entry, wait for reaction to be generated, open detail view - reaction is displayed
- [ ] Entries without reactions display normally without errors