### PR TITLE
Fix Claude Code detector to check correct env vars

### DIFF
--- a/src/infrastructure/agent/detectors/claude-code-detector.test.ts
+++ b/src/infrastructure/agent/detectors/claude-code-detector.test.ts
@@ -7,6 +7,12 @@ describe('claudeCodeDetector', () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    // Clean all Claude Code env vars to ensure test isolation
+    delete process.env['CLAUDECODE'];
+    delete process.env['CLAUDE_CODE_ENTRYPOINT'];
+    delete process.env['CLAUDE_CODE'];
+    delete process.env['CLAUDE_CODE_VERSION'];
+    delete process.env['CLAUDE_CODE_SESSION_ID'];
   });
 
   afterEach(() => {
@@ -15,6 +21,36 @@ describe('claudeCodeDetector', () => {
 
   it('should have correct agent type', () => {
     expect(claudeCodeDetector.agentType).toBe(AgentType.ClaudeCode);
+  });
+
+  it('should detect via CLAUDECODE env var', async () => {
+    process.env['CLAUDECODE'] = '1';
+
+    const result = await claudeCodeDetector.detect();
+
+    expect(result).toEqual({
+      agent: AgentType.ClaudeCode,
+      detectionMethod: 'env',
+      metadata: {
+        envVar: 'CLAUDECODE',
+        value: '1',
+      },
+    });
+  });
+
+  it('should detect via CLAUDE_CODE_ENTRYPOINT env var', async () => {
+    process.env['CLAUDE_CODE_ENTRYPOINT'] = 'cli';
+
+    const result = await claudeCodeDetector.detect();
+
+    expect(result).toEqual({
+      agent: AgentType.ClaudeCode,
+      detectionMethod: 'env',
+      metadata: {
+        envVar: 'CLAUDE_CODE_ENTRYPOINT',
+        value: 'cli',
+      },
+    });
   });
 
   it('should detect via CLAUDE_CODE env var', async () => {
@@ -63,6 +99,8 @@ describe('claudeCodeDetector', () => {
   });
 
   it('should return null when no Claude Code env vars are set', async () => {
+    delete process.env['CLAUDECODE'];
+    delete process.env['CLAUDE_CODE_ENTRYPOINT'];
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_VERSION;
     delete process.env.CLAUDE_CODE_SESSION_ID;
@@ -81,11 +119,12 @@ describe('claudeCodeDetector', () => {
   });
 
   it('should prioritize first matching env var', async () => {
+    process.env['CLAUDECODE'] = '1';
     process.env.CLAUDE_CODE = '1';
     process.env.CLAUDE_CODE_VERSION = '1.0.0';
 
     const result = await claudeCodeDetector.detect();
 
-    expect(result?.metadata?.envVar).toBe('CLAUDE_CODE');
+    expect(result?.metadata?.envVar).toBe('CLAUDECODE');
   });
 });

--- a/src/infrastructure/agent/detectors/claude-code-detector.ts
+++ b/src/infrastructure/agent/detectors/claude-code-detector.ts
@@ -4,6 +4,8 @@ import { type AgentDetectionResult, type AgentDetector, AgentType } from '../typ
  * Environment variables that indicate Claude Code is running
  */
 const CLAUDE_CODE_ENV_VARS = [
+  'CLAUDECODE',
+  'CLAUDE_CODE_ENTRYPOINT',
   'CLAUDE_CODE',
   'CLAUDE_CODE_VERSION',
   'CLAUDE_CODE_SESSION_ID',


### PR DESCRIPTION
## Summary

Fixes #68 - Claude Code detector now checks the correct environment variable names that Claude Code actually sets.

- Add `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` to the detector's env var list
- Keep existing vars (`CLAUDE_CODE`, `CLAUDE_CODE_VERSION`, `CLAUDE_CODE_SESSION_ID`) for backwards compatibility
- New vars are checked first since they are the actual ones set by Claude Code

## Changes

- **src/infrastructure/agent/detectors/claude-code-detector.ts**: Add `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` to the beginning of `CLAUDE_CODE_ENV_VARS` array
- **src/infrastructure/agent/detectors/claude-code-detector.test.ts**: Add tests for new env vars, update existing tests for new ordering and cleanup

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm vitest run src/infrastructure/agent/detectors/claude-code-detector.test.ts` - all tests pass
- [ ] Verify detection works with `CLAUDECODE=1` set
- [ ] Verify detection works with `CLAUDE_CODE_ENTRYPOINT=cli` set