### PR TITLE
Add agent-agnostic status monitoring with Gemini CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ ollama pull qwen2.5-coder:7b
 | `MUMBL_OLLAMA_MODEL` | `qwen2.5-coder:7b` | Default model to use |
 | `MUMBL_OLLAMA_TIMEOUT` | `30000` | Connection timeout (ms) |
 
-### Claude Code Integration
+### Agent Status Integration
 
-mumbl can display real-time AI agent activity in the terminal title. When Claude Code is processing, the terminal title updates to show its status.
+mumbl can display real-time AI agent activity in the terminal title. When a coding agent (Claude Code, Gemini CLI) is processing, the terminal title updates to show its status.
 
-#### Hook Configuration
+#### Claude Code
 
 Add the following to your Claude Code settings file (`~/.claude/settings.json`):
 
@@ -63,7 +63,7 @@ Add the following to your Claude Code settings file (`~/.claude/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "echo -n 'thinking' > /tmp/mumbl-claude-status"
+            "command": "echo -n 'thinking:claude-code' > /tmp/mumbl-agent-status"
           }
         ]
       }
@@ -74,7 +74,7 @@ Add the following to your Claude Code settings file (`~/.claude/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "echo -n 'idle' > /tmp/mumbl-claude-status"
+            "command": "echo -n 'idle:claude-code' > /tmp/mumbl-agent-status"
           }
         ]
       }
@@ -83,24 +83,48 @@ Add the following to your Claude Code settings file (`~/.claude/settings.json`):
 }
 ```
 
+#### Gemini CLI
+
+Add the following to your Gemini CLI settings file (`~/.gemini/settings.json`):
+
+```json
+{
+  "hooks": {
+    "BeforeTool": [
+      {
+        "command": "echo -n 'thinking:gemini-cli' > /tmp/mumbl-agent-status"
+      }
+    ],
+    "AfterAgent": [
+      {
+        "command": "echo -n 'idle:gemini-cli' > /tmp/mumbl-agent-status"
+      }
+    ]
+  }
+}
+```
+
 #### How It Works
 
-1. **Claude Code triggers a hook** before each tool use, writing `thinking` to the status file
-2. **mumbl watches the status file** (`/tmp/mumbl-claude-status`) for changes
-3. **The terminal title updates** to show the agent's current activity (e.g., "Claude thinking...")
-4. **When Claude Code stops**, the `Stop` hook writes `idle` and the title resets to "mumbl"
+1. **An agent triggers a hook** before each tool use, writing status to `/tmp/mumbl-agent-status`
+2. **mumbl watches the status file** for changes using `fs.watch` and polling
+3. **The terminal title updates** to show the agent's current activity (e.g., "Claude thinking...", "Gemini thinking...")
+4. **When the agent stops**, the hook writes `idle` and the title resets to "mumbl"
+
+The status file format supports an extended format (`thinking:agent-name`) for agent identification, and plain `thinking`/`idle` for backward compatibility.
 
 #### Verification
 
-You can manually test the integration without Claude Code:
+You can manually test the integration:
 
 ```bash
 # Start mumbl in one terminal
 pnpm dev
 
 # In another terminal, simulate agent activity:
-echo -n 'thinking' > /tmp/mumbl-claude-status   # Title changes to "Claude thinking..."
-echo -n 'idle' > /tmp/mumbl-claude-status        # Title resets to "mumbl"
+echo -n 'thinking:claude-code' > /tmp/mumbl-agent-status   # "Claude thinking..."
+echo -n 'thinking:gemini-cli' > /tmp/mumbl-agent-status    # "Gemini thinking..."
+echo -n 'idle:claude-code' > /tmp/mumbl-agent-status       # Title resets to "mumbl"
 ```
 
 ### Setup

--- a/src/hooks/useAgentStatus.test.ts
+++ b/src/hooks/useAgentStatus.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AGENT_STATUS_FILE_PATH,
+  AgentType,
+  parseAgentName,
+  readAgentStatusFile,
+} from './useAgentStatus.js';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+    watch: vi.fn(),
+  };
+});
+
+const fsMock = await import('node:fs');
+const readFileSyncMock = vi.mocked(fsMock.readFileSync);
+
+describe('useAgentStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('AGENT_STATUS_FILE_PATH', () => {
+    it('should be /tmp/mumbl-agent-status', () => {
+      expect(AGENT_STATUS_FILE_PATH).toBe('/tmp/mumbl-agent-status');
+    });
+  });
+
+  describe('parseAgentName', () => {
+    it('should parse claude-code', () => {
+      expect(parseAgentName('claude-code')).toBe(AgentType.ClaudeCode);
+    });
+
+    it('should parse gemini-cli', () => {
+      expect(parseAgentName('gemini-cli')).toBe(AgentType.GeminiCLI);
+    });
+
+    it('should parse cursor', () => {
+      expect(parseAgentName('cursor')).toBe(AgentType.Cursor);
+    });
+
+    it('should parse windsurf', () => {
+      expect(parseAgentName('windsurf')).toBe(AgentType.Windsurf);
+    });
+
+    it('should return Unknown for unrecognized agent', () => {
+      expect(parseAgentName('unknown-agent')).toBe(AgentType.Unknown);
+    });
+
+    it('should handle case-insensitive input', () => {
+      expect(parseAgentName('Claude-Code')).toBe(AgentType.ClaudeCode);
+    });
+
+    it('should trim whitespace', () => {
+      expect(parseAgentName('  gemini-cli  ')).toBe(AgentType.GeminiCLI);
+    });
+  });
+
+  describe('readAgentStatusFile', () => {
+    it('should parse thinking:claude-code format', () => {
+      readFileSyncMock.mockReturnValue('thinking:claude-code');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'thinking', agent: AgentType.ClaudeCode });
+    });
+
+    it('should parse thinking:gemini-cli format', () => {
+      readFileSyncMock.mockReturnValue('thinking:gemini-cli');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'thinking', agent: AgentType.GeminiCLI });
+    });
+
+    it('should parse idle:claude-code format', () => {
+      readFileSyncMock.mockReturnValue('idle:claude-code');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'idle', agent: AgentType.ClaudeCode });
+    });
+
+    it('should handle plain thinking (backward compatibility)', () => {
+      readFileSyncMock.mockReturnValue('thinking');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'thinking', agent: AgentType.Unknown });
+    });
+
+    it('should return idle for plain idle', () => {
+      readFileSyncMock.mockReturnValue('idle');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'idle', agent: AgentType.Unknown });
+    });
+
+    it('should return idle when file is missing', () => {
+      readFileSyncMock.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'idle', agent: AgentType.Unknown });
+    });
+
+    it('should return idle when file is empty', () => {
+      readFileSyncMock.mockReturnValue('');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'idle', agent: AgentType.Unknown });
+    });
+
+    it('should return idle for invalid content', () => {
+      readFileSyncMock.mockReturnValue('invalid');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'idle', agent: AgentType.Unknown });
+    });
+
+    it('should accept a custom file path', () => {
+      readFileSyncMock.mockReturnValue('thinking:claude-code');
+      readAgentStatusFile('/custom/path');
+      expect(readFileSyncMock).toHaveBeenCalledWith('/custom/path', 'utf-8');
+    });
+
+    it('should handle unknown agent in extended format', () => {
+      readFileSyncMock.mockReturnValue('thinking:some-new-agent');
+      const result = readAgentStatusFile();
+      expect(result).toEqual({ status: 'thinking', agent: AgentType.Unknown });
+    });
+  });
+
+  describe('useAgentStatus hook', () => {
+    it('should be exported as a function', async () => {
+      readFileSyncMock.mockReturnValue('idle');
+      const { useAgentStatus } = await import('./useAgentStatus.js');
+      expect(useAgentStatus).toBeDefined();
+      expect(typeof useAgentStatus).toBe('function');
+    });
+  });
+});

--- a/src/hooks/useAgentStatus.ts
+++ b/src/hooks/useAgentStatus.ts
@@ -1,0 +1,96 @@
+import { type FSWatcher, readFileSync, watch } from 'node:fs';
+import { useEffect, useState } from 'react';
+
+export enum AgentType {
+  ClaudeCode = 'claude-code',
+  GeminiCLI = 'gemini-cli',
+  Cursor = 'cursor',
+  Windsurf = 'windsurf',
+  Unknown = 'unknown',
+}
+
+export type AgentActivityStatus = 'thinking' | 'idle';
+
+export interface AgentStatusInfo {
+  status: AgentActivityStatus;
+  agent: AgentType;
+}
+
+export const AGENT_STATUS_FILE_PATH = '/tmp/mumbl-agent-status';
+
+const DEFAULT_STATUS: AgentStatusInfo = {
+  status: 'idle',
+  agent: AgentType.Unknown,
+};
+
+export function parseAgentName(name: string): AgentType {
+  const normalized = name.trim().toLowerCase();
+  switch (normalized) {
+    case 'claude-code':
+      return AgentType.ClaudeCode;
+    case 'gemini-cli':
+      return AgentType.GeminiCLI;
+    case 'cursor':
+      return AgentType.Cursor;
+    case 'windsurf':
+      return AgentType.Windsurf;
+    default:
+      return AgentType.Unknown;
+  }
+}
+
+export function readAgentStatusFile(filePath: string = AGENT_STATUS_FILE_PATH): AgentStatusInfo {
+  try {
+    const content = readFileSync(filePath, 'utf-8').trim();
+
+    if (content.includes(':')) {
+      const colonIndex = content.indexOf(':');
+      const statusPart = content.substring(0, colonIndex);
+      const agentPart = content.substring(colonIndex + 1);
+
+      if (statusPart === 'thinking') {
+        return { status: 'thinking', agent: parseAgentName(agentPart) };
+      }
+      return { status: 'idle', agent: parseAgentName(agentPart) };
+    }
+
+    if (content === 'thinking') {
+      return { status: 'thinking', agent: AgentType.Unknown };
+    }
+
+    return DEFAULT_STATUS;
+  } catch {
+    return DEFAULT_STATUS;
+  }
+}
+
+export function useAgentStatus(): AgentStatusInfo {
+  const [statusInfo, setStatusInfo] = useState<AgentStatusInfo>(() => readAgentStatusFile());
+
+  useEffect(() => {
+    let watcher: FSWatcher | undefined;
+
+    const updateStatus = () => {
+      setStatusInfo(readAgentStatusFile());
+    };
+
+    try {
+      watcher = watch(AGENT_STATUS_FILE_PATH, () => {
+        updateStatus();
+      });
+    } catch {
+      // File may not exist yet, polling will handle it
+    }
+
+    const interval = setInterval(updateStatus, 1000);
+
+    return () => {
+      if (watcher) {
+        watcher.close();
+      }
+      clearInterval(interval);
+    };
+  }, []);
+
+  return statusInfo;
+}

--- a/src/hooks/useClaudeStatus.test.ts
+++ b/src/hooks/useClaudeStatus.test.ts
@@ -12,7 +12,6 @@ vi.mock('node:fs', async () => {
 
 const fsMock = await import('node:fs');
 const readFileSyncMock = vi.mocked(fsMock.readFileSync);
-const watchMock = vi.mocked(fsMock.watch);
 
 describe('useClaudeStatus', () => {
   beforeEach(() => {
@@ -75,26 +74,12 @@ describe('useClaudeStatus', () => {
     });
   });
 
-  describe('useClaudeStatus hook', () => {
-    it('should set up watcher and polling on mount', async () => {
+  describe('useClaudeStatus deprecated wrapper', () => {
+    it('should be a function that wraps useAgentStatus', async () => {
       readFileSyncMock.mockReturnValue('idle');
-      const closeMock = vi.fn();
-      watchMock.mockReturnValue({ close: closeMock } as unknown as fsMock.FSWatcher);
-
       const { useClaudeStatus } = await import('./useClaudeStatus.js');
       expect(useClaudeStatus).toBeDefined();
       expect(typeof useClaudeStatus).toBe('function');
-    });
-
-    it('should handle watch throwing when file does not exist', () => {
-      readFileSyncMock.mockReturnValue('idle');
-      watchMock.mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
-
-      expect(() => {
-        watchMock(STATUS_FILE_PATH, () => {});
-      }).toThrow('ENOENT');
     });
   });
 });

--- a/src/hooks/useClaudeStatus.ts
+++ b/src/hooks/useClaudeStatus.ts
@@ -1,7 +1,9 @@
-import { type FSWatcher, readFileSync, watch } from 'node:fs';
-import { useEffect, useState } from 'react';
+import { readFileSync } from 'node:fs';
+import type { AgentActivityStatus } from './useAgentStatus.js';
+import { useAgentStatus } from './useAgentStatus.js';
 
-export type AgentStatus = 'thinking' | 'idle';
+/** @deprecated Use AgentActivityStatus from useAgentStatus instead */
+export type AgentStatus = AgentActivityStatus;
 
 export const STATUS_FILE_PATH = '/tmp/mumbl-claude-status';
 
@@ -14,33 +16,8 @@ export function readStatusFile(filePath: string = STATUS_FILE_PATH): AgentStatus
   }
 }
 
-export function useClaudeStatus(): AgentStatus {
-  const [status, setStatus] = useState<AgentStatus>(() => readStatusFile());
-
-  useEffect(() => {
-    let watcher: FSWatcher | undefined;
-
-    const updateStatus = () => {
-      setStatus(readStatusFile());
-    };
-
-    try {
-      watcher = watch(STATUS_FILE_PATH, () => {
-        updateStatus();
-      });
-    } catch {
-      // File may not exist yet, polling will handle it
-    }
-
-    const interval = setInterval(updateStatus, 1000);
-
-    return () => {
-      if (watcher) {
-        watcher.close();
-      }
-      clearInterval(interval);
-    };
-  }, []);
-
+/** @deprecated Use useAgentStatus instead */
+export function useClaudeStatus(): AgentActivityStatus {
+  const { status } = useAgentStatus();
   return status;
 }

--- a/src/hooks/useTerminalTitle.test.ts
+++ b/src/hooks/useTerminalTitle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentStatus } from './useClaudeStatus.js';
-import { getTitle, setTerminalTitle } from './useTerminalTitle.js';
+import type { AgentStatusInfo } from './useAgentStatus.js';
+import { AgentType } from './useAgentStatus.js';
+import { getAgentDisplayName, getTitle, setTerminalTitle } from './useTerminalTitle.js';
 
 describe('useTerminalTitle', () => {
   let writeSpy: ReturnType<typeof vi.spyOn>;
@@ -25,20 +26,52 @@ describe('useTerminalTitle', () => {
     });
   });
 
+  describe('getAgentDisplayName', () => {
+    it('should return Claude for ClaudeCode', () => {
+      expect(getAgentDisplayName(AgentType.ClaudeCode)).toBe('Claude');
+    });
+
+    it('should return Gemini for GeminiCLI', () => {
+      expect(getAgentDisplayName(AgentType.GeminiCLI)).toBe('Gemini');
+    });
+
+    it('should return Cursor for Cursor', () => {
+      expect(getAgentDisplayName(AgentType.Cursor)).toBe('Cursor');
+    });
+
+    it('should return Windsurf for Windsurf', () => {
+      expect(getAgentDisplayName(AgentType.Windsurf)).toBe('Windsurf');
+    });
+
+    it('should return Agent for Unknown', () => {
+      expect(getAgentDisplayName(AgentType.Unknown)).toBe('Agent');
+    });
+  });
+
   describe('getTitle', () => {
-    it('should return thinking title for thinking status', () => {
-      const result = getTitle('thinking');
-      expect(result).toBe('\u2699 Claude thinking...');
+    it('should return Claude thinking title for thinking claude-code', () => {
+      const info: AgentStatusInfo = { status: 'thinking', agent: AgentType.ClaudeCode };
+      expect(getTitle(info)).toBe('\u2699 Claude thinking...');
+    });
+
+    it('should return Gemini thinking title for thinking gemini-cli', () => {
+      const info: AgentStatusInfo = { status: 'thinking', agent: AgentType.GeminiCLI };
+      expect(getTitle(info)).toBe('\u2699 Gemini thinking...');
+    });
+
+    it('should return Agent thinking for unknown agent', () => {
+      const info: AgentStatusInfo = { status: 'thinking', agent: AgentType.Unknown };
+      expect(getTitle(info)).toBe('\u2699 Agent thinking...');
     });
 
     it('should return mumbl for idle status', () => {
-      const result = getTitle('idle');
-      expect(result).toBe('mumbl');
+      const info: AgentStatusInfo = { status: 'idle', agent: AgentType.ClaudeCode };
+      expect(getTitle(info)).toBe('mumbl');
     });
 
-    it('should return mumbl for any non-thinking status', () => {
-      const result = getTitle('idle' as AgentStatus);
-      expect(result).toBe('mumbl');
+    it('should return mumbl for idle with any agent', () => {
+      const info: AgentStatusInfo = { status: 'idle', agent: AgentType.GeminiCLI };
+      expect(getTitle(info)).toBe('mumbl');
     });
   });
 });

--- a/src/hooks/useTerminalTitle.ts
+++ b/src/hooks/useTerminalTitle.ts
@@ -1,20 +1,39 @@
 import { useEffect } from 'react';
-import type { AgentStatus } from './useClaudeStatus.js';
+import { type AgentStatusInfo, AgentType } from './useAgentStatus.js';
 
 export function setTerminalTitle(title: string): void {
   process.stdout.write(`\x1b]0;${title}\x07`);
 }
 
-export function getTitle(status: AgentStatus): string {
-  return status === 'thinking' ? '\u2699 Claude thinking...' : 'mumbl';
+export function getAgentDisplayName(agent: AgentType): string {
+  switch (agent) {
+    case AgentType.ClaudeCode:
+      return 'Claude';
+    case AgentType.GeminiCLI:
+      return 'Gemini';
+    case AgentType.Cursor:
+      return 'Cursor';
+    case AgentType.Windsurf:
+      return 'Windsurf';
+    default:
+      return 'Agent';
+  }
 }
 
-export function useTerminalTitle(status: AgentStatus): void {
+export function getTitle(statusInfo: AgentStatusInfo): string {
+  if (statusInfo.status === 'thinking') {
+    const agentName = getAgentDisplayName(statusInfo.agent);
+    return `\u2699 ${agentName} thinking...`;
+  }
+  return 'mumbl';
+}
+
+export function useTerminalTitle(statusInfo: AgentStatusInfo): void {
   useEffect(() => {
-    setTerminalTitle(getTitle(status));
+    setTerminalTitle(getTitle(statusInfo));
 
     return () => {
       setTerminalTitle('mumbl');
     };
-  }, [status]);
+  }, [statusInfo]);
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useApp, useInput } from 'ink';
 import React, { useState } from 'react';
-import { useClaudeStatus } from '../hooks/useClaudeStatus.js';
+import { useAgentStatus } from '../hooks/useAgentStatus.js';
 import { useTerminalTitle } from '../hooks/useTerminalTitle.js';
 import { HelpFooter } from './components/common/HelpFooter.js';
 import { ModeIndicator } from './components/common/ModeIndicator.js';
@@ -15,8 +15,8 @@ function AppContent() {
   const { mode, toggleMode } = useNavigation();
   const { status: queueStatus } = useQueue();
   const [isViewingDetail, setIsViewingDetail] = useState(false);
-  const claudeStatus = useClaudeStatus();
-  useTerminalTitle(claudeStatus);
+  const agentStatus = useAgentStatus();
+  useTerminalTitle(agentStatus);
 
   useInput((input, key) => {
     if (input === 'q' || (key.ctrl && input === 'c')) {


### PR DESCRIPTION
## Summary

Implements issue #74 by creating an agent-agnostic `useAgentStatus` hook that supports multiple AI coding agents (Claude Code, Gemini CLI, Cursor, Windsurf). Depends on #71 and #72.

- `useAgentStatus` hook with extended format (`thinking:agent-name`)
- Agent-specific terminal titles (e.g., "Claude thinking...", "Gemini thinking...")
- Backward-compatible `useClaudeStatus` deprecated wrapper
- Updated documentation with Gemini CLI hook configuration

## Changes

- **src/hooks/useAgentStatus.ts**: New agent-agnostic hook with `parseAgentName`, `readAgentStatusFile`
- **src/hooks/useAgentStatus.test.ts**: Comprehensive tests (19 test cases)
- **src/hooks/useClaudeStatus.ts**: Refactored to deprecated wrapper
- **src/hooks/useClaudeStatus.test.ts**: Updated tests for wrapper
- **src/hooks/useTerminalTitle.ts**: Accepts `AgentStatusInfo`, shows agent-specific titles
- **src/hooks/useTerminalTitle.test.ts**: Updated tests with agent display names
- **src/ui/App.tsx**: Uses `useAgentStatus` instead of `useClaudeStatus`
- **README.md**: Added Gemini CLI config, updated Claude Code config

## Dependencies

- Requires #71 and #72 to be merged first (branch is based on #72)

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm ci:check` passes (lint + format)
- [x] `pnpm test:coverage` passes (84.45% overall, 41 hook tests)
- [x] All 630+ tests pass