### PR TITLE
Fix cursor position and reaction visibility after journal creation

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -77,10 +77,16 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
     [flatList],
   );
 
-  const { selectedIndex } = useKeyboardNavigation({
+  // Resolve -1 sentinel to last entry index
+  const resolvedInitialIndex =
+    listState.selectedIndex === -1 && entryItems.length > 0
+      ? entryItems.length - 1
+      : listState.selectedIndex;
+
+  const { selectedIndex, setSelectedIndex } = useKeyboardNavigation({
     itemCount: entryItems.length,
     enabled: !viewingEntry,
-    initialIndex: listState.selectedIndex,
+    initialIndex: resolvedInitialIndex,
     onAction: () => {
       const selectedEntry = entryItems[selectedIndex]?.entry;
       if (selectedEntry) {
@@ -91,6 +97,15 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
       setListState({ selectedIndex: index });
     },
   });
+
+  // When entries load and sentinel was set, update to last entry
+  useEffect(() => {
+    if (listState.selectedIndex === -1 && entryItems.length > 0) {
+      const lastIndex = entryItems.length - 1;
+      setSelectedIndex(lastIndex);
+      setListState({ selectedIndex: lastIndex });
+    }
+  }, [listState.selectedIndex, entryItems.length, setSelectedIndex, setListState]);
 
   // Map flat list index to selected entry
   const selectedEntryId = entryItems[selectedIndex]?.entry?.id;
@@ -107,11 +122,11 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // Calculate viewport height: terminal rows - header (2 lines) - padding (2 lines) - footer reserve (3 lines)
   const viewportHeight = Math.max(5, terminalRows - 7);
 
-  // Calculate item heights: entries with reactions = 2 lines, headers = 1 line, entries without reactions = 1 line
+  // Calculate item heights: entries with reactions = 2 lines, headers = 3 lines, entries without reactions = 1 line
   const itemHeights = useMemo(() => {
     return flatList.map((item) => {
       if (item.type === 'header') {
-        return 1;
+        return 3; // 1 line content + marginY={1} (1 above + 1 below)
       }
       // Entry with reaction takes 2 lines, without reaction takes 1 line
       return reactions.has(item.entry.id) ? 2 : 1;

--- a/src/ui/components/write/WriteView.tsx
+++ b/src/ui/components/write/WriteView.tsx
@@ -24,7 +24,7 @@ export function WriteView() {
       if (trimmedContent) {
         entryService.create({ content: trimmedContent });
         setWriteState({ content: '' });
-        switchToList();
+        switchToList({ selectLastEntry: true });
       }
       return;
     }

--- a/src/ui/context/NavigationContext.tsx
+++ b/src/ui/context/NavigationContext.tsx
@@ -10,9 +10,13 @@ interface WriteState {
   content: string;
 }
 
+interface SwitchToListOptions {
+  selectLastEntry?: boolean;
+}
+
 interface NavigationContextValue {
   mode: AppMode;
-  switchToList: () => void;
+  switchToList: (options?: SwitchToListOptions) => void;
   switchToWrite: () => void;
   toggleMode: () => void;
   listState: ListState;
@@ -41,7 +45,10 @@ export function NavigationProvider({ children, initialMode = 'list' }: Navigatio
   const [listState, setListState] = useState<ListState>({ selectedIndex: 0 });
   const [writeState, setWriteState] = useState<WriteState>({ content: '' });
 
-  const switchToList = useCallback(() => {
+  const switchToList = useCallback((options?: SwitchToListOptions) => {
+    if (options?.selectLastEntry) {
+      setListState({ selectedIndex: -1 });
+    }
     setMode('list');
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes #87 - Two bugs in the journal entry list view after creating a new entry.

- Fix cursor landing on previous entry instead of newly created one by adding `selectLastEntry` option to `switchToList()`
- Fix reaction visibility clipping caused by incorrect header height calculation (`marginY={1}` = 3 lines, not 1)

## Changes

- **NavigationContext.tsx**: Add `SwitchToListOptions` interface with `selectLastEntry` flag; when set, stores `-1` sentinel in `selectedIndex`
- **WriteView.tsx**: Use `switchToList({ selectLastEntry: true })` after entry creation
- **EntryList.tsx**: Resolve `-1` sentinel to last entry index via `useEffect`; fix header `itemHeights` from `1` to `3` to match `marginY={1}` rendering

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] All 382 unit tests pass
- [ ] Manual: Create new journal entry, verify cursor lands on new entry
- [ ] Manual: Scroll through list, verify all reactions remain visible
- [ ] Manual: Navigate around group headers, verify no clipping