### PR TITLE
Add language-aware reactions with auto-detection

### DIFF
--- a/src/infrastructure/config/reaction-config.ts
+++ b/src/infrastructure/config/reaction-config.ts
@@ -1,6 +1,8 @@
 import type { ReactionType } from '../../repositories/types.js';
 import type { ReactionConfig } from '../../services/reaction-service.js';
 
+type LanguageMode = 'auto' | 'ja' | 'en';
+
 /**
  * Get reaction configuration from environment variables
  *
@@ -8,11 +10,14 @@ import type { ReactionConfig } from '../../services/reaction-service.js';
  * - MUMBL_REACTIONS_ENABLED: Enable/disable reactions (default: true)
  * - MUMBL_REACTION_TYPE: Default reaction type (default: 'read')
  * - MUMBL_REACTION_USE_LLM: Use LLM for generating reactions (default: true)
+ * - MUMBL_REACTION_LANGUAGE: Language mode for reactions (default: 'auto')
+ *   Values: 'auto' | 'ja' | 'en'
  */
 export function getReactionConfig(): ReactionConfig {
   const enabledEnv = process.env['MUMBL_REACTIONS_ENABLED'];
   const reactionTypeEnv = process.env['MUMBL_REACTION_TYPE'];
   const useLLMEnv = process.env['MUMBL_REACTION_USE_LLM'];
+  const languageEnv = process.env['MUMBL_REACTION_LANGUAGE'];
 
   // Parse enabled - defaults to true, only false if explicitly set to 'false'
   const enabled = enabledEnv !== 'false';
@@ -28,9 +33,16 @@ export function getReactionConfig(): ReactionConfig {
   // Parse useLLM - defaults to true, only false if explicitly set to 'false'
   const useLLM = useLLMEnv !== 'false';
 
+  // Parse language mode - validate against allowed values, default to 'auto'
+  const validLanguageModes: LanguageMode[] = ['auto', 'ja', 'en'];
+  const language: LanguageMode = validLanguageModes.includes(languageEnv as LanguageMode)
+    ? (languageEnv as LanguageMode)
+    : 'auto';
+
   return {
     enabled,
     defaultReactionType,
     useLLM,
+    language,
   };
 }

--- a/src/services/language/detect.test.ts
+++ b/src/services/language/detect.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { detectLanguage } from './detect.js';
+
+describe('detectLanguage', () => {
+  describe('Japanese text', () => {
+    it('should detect hiragana text as Japanese', () => {
+      expect(detectLanguage('おはよう')).toBe('ja');
+    });
+
+    it('should detect katakana text as Japanese', () => {
+      expect(detectLanguage('コーヒー')).toBe('ja');
+    });
+
+    it('should detect kanji text as Japanese', () => {
+      expect(detectLanguage('仕事つらい')).toBe('ja');
+    });
+
+    it('should detect mixed Japanese text', () => {
+      expect(detectLanguage('今日はカフェでコーヒーを飲んだ')).toBe('ja');
+    });
+
+    it('should detect Japanese with some ASCII', () => {
+      expect(detectLanguage('今日はOKだった')).toBe('ja');
+    });
+  });
+
+  describe('English text', () => {
+    it('should detect plain English text', () => {
+      expect(detectLanguage('I had a good day today')).toBe('en');
+    });
+
+    it('should detect short English text', () => {
+      expect(detectLanguage('hello')).toBe('en');
+    });
+
+    it('should detect English with numbers', () => {
+      expect(detectLanguage('worked 8 hours today')).toBe('en');
+    });
+  });
+
+  describe('mixed content', () => {
+    it('should detect as Japanese when CJK ratio exceeds threshold', () => {
+      // More than 10% CJK characters
+      expect(detectLanguage('今日 is good')).toBe('ja');
+    });
+
+    it('should detect as English when CJK ratio is below threshold', () => {
+      // Very few CJK characters relative to total
+      expect(detectLanguage('This is a very long English sentence with just one 字')).toBe('en');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return en for empty string', () => {
+      expect(detectLanguage('')).toBe('en');
+    });
+
+    it('should return en for whitespace-only string', () => {
+      expect(detectLanguage('   ')).toBe('en');
+    });
+
+    it('should return en for numbers only', () => {
+      expect(detectLanguage('12345')).toBe('en');
+    });
+
+    it('should return en for symbols only', () => {
+      expect(detectLanguage('!@#$%')).toBe('en');
+    });
+  });
+});

--- a/src/services/language/detect.ts
+++ b/src/services/language/detect.ts
@@ -1,0 +1,27 @@
+import type { DetectedLanguage } from './types.js';
+
+/**
+ * Regex matching CJK characters commonly used in Japanese text:
+ * - CJK Unified Ideographs (U+4E00-U+9FFF)
+ * - Hiragana (U+3040-U+309F)
+ * - Katakana (U+30A0-U+30FF)
+ */
+const CJK_PATTERN = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
+
+/**
+ * Detect the language of a given text.
+ * Returns 'ja' if CJK characters make up more than 10% of the text,
+ * otherwise returns 'en'.
+ */
+export function detectLanguage(text: string): DetectedLanguage {
+  const stripped = text.replace(/\s/g, '');
+  if (stripped.length === 0) {
+    return 'en';
+  }
+
+  const cjkMatches = stripped.match(CJK_PATTERN);
+  const cjkCount = cjkMatches ? cjkMatches.length : 0;
+  const ratio = cjkCount / stripped.length;
+
+  return ratio > 0.1 ? 'ja' : 'en';
+}

--- a/src/services/language/index.ts
+++ b/src/services/language/index.ts
@@ -1,0 +1,3 @@
+export { detectLanguage } from './detect.js';
+export type { DetectedLanguage, LanguageConfig } from './types.js';
+export { getWordListForLanguage, REACTION_WORDS } from './word-lists.js';

--- a/src/services/language/types.ts
+++ b/src/services/language/types.ts
@@ -1,0 +1,6 @@
+export type DetectedLanguage = 'ja' | 'en';
+
+export interface LanguageConfig {
+  defaultLanguage: DetectedLanguage;
+  mode: 'auto' | DetectedLanguage;
+}

--- a/src/services/language/word-lists.test.ts
+++ b/src/services/language/word-lists.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { REACTION_WORDS, getWordListForLanguage } from './word-lists.js';
+
+describe('REACTION_WORDS', () => {
+  it('should have entries for both languages', () => {
+    expect(REACTION_WORDS.en).toBeDefined();
+    expect(REACTION_WORDS.ja).toBeDefined();
+  });
+
+  it('should have the same number of categories for each language', () => {
+    expect(REACTION_WORDS.en.length).toBe(REACTION_WORDS.ja.length);
+  });
+
+  it('should have non-empty word arrays in all categories', () => {
+    for (const lang of ['en', 'ja'] as const) {
+      for (const category of REACTION_WORDS[lang]) {
+        expect(category.words.length).toBeGreaterThan(0);
+        expect(category.label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('should include neutral category with dot for both languages', () => {
+    for (const lang of ['en', 'ja'] as const) {
+      const neutral = REACTION_WORDS[lang].find((c) => c.label === 'Neutral');
+      expect(neutral).toBeDefined();
+      expect(neutral?.words).toContain('\u00B7');
+    }
+  });
+});
+
+describe('getWordListForLanguage', () => {
+  it('should return a formatted string for English', () => {
+    const result = getWordListForLanguage('en');
+    expect(result).toContain('- Acknowledgment:');
+    expect(result).toContain('bet');
+    expect(result).toContain('- Negative/tough:');
+    expect(result).toContain('- Positive vibes:');
+    expect(result).toContain('- Feeling it:');
+    expect(result).toContain('- Neutral:');
+  });
+
+  it('should return a formatted string for Japanese', () => {
+    const result = getWordListForLanguage('ja');
+    expect(result).toContain('- Acknowledgment:');
+    expect(result).toContain('na');
+    expect(result).toContain('wakaru');
+    expect(result).toContain('- Neutral:');
+  });
+
+  it('should have one line per category', () => {
+    const enLines = getWordListForLanguage('en').split('\n');
+    const jaLines = getWordListForLanguage('ja').split('\n');
+    expect(enLines.length).toBe(REACTION_WORDS.en.length);
+    expect(jaLines.length).toBe(REACTION_WORDS.ja.length);
+  });
+});

--- a/src/services/language/word-lists.ts
+++ b/src/services/language/word-lists.ts
@@ -1,0 +1,40 @@
+import type { DetectedLanguage } from './types.js';
+
+interface WordCategory {
+  label: string;
+  words: string[];
+}
+
+/**
+ * Reaction words organized by language and category.
+ */
+export const REACTION_WORDS: Record<DetectedLanguage, WordCategory[]> = {
+  en: [
+    {
+      label: 'Acknowledgment',
+      words: ['bet', 'word', 'aight', 'cool', 'k', 'yo', 'yea', 'uh-huh'],
+    },
+    { label: 'Negative/tough', words: ['damn', 'oof', 'rough', 'bruh', 'yikes', 'sheesh', 'nah'] },
+    { label: 'Positive vibes', words: ['lit', 'fire', 'dope', 'nice', 'sick', 'tight', 'valid'] },
+    { label: 'Feeling it', words: ['fr', 'real', 'facts', 'mood', 'felt', 'same', 'true'] },
+    { label: 'Neutral', words: ['\u00B7'] },
+  ],
+  ja: [
+    { label: 'Acknowledgment', words: ['na', 'un', 'sou', 'oke', 'hai', 'ah', 'nn'] },
+    { label: 'Negative/tough', words: ['tsura', 'yaba', 'uwa', 'geh', 'maji', 'ore-mo', 'ita'] },
+    { label: 'Positive vibes', words: ['ii', 'yoi', 'saikou', 'kami', 'yoshi', 'ii-ne', 'naisuu'] },
+    {
+      label: 'Feeling it',
+      words: ['wakaru', 'sore-na', 'dakara', 'honma', 'sore', 'tashika-ni', 'ne'],
+    },
+    { label: 'Neutral', words: ['\u00B7'] },
+  ],
+};
+
+/**
+ * Format a word list for a given language into a prompt-ready string.
+ */
+export function getWordListForLanguage(language: DetectedLanguage): string {
+  const categories = REACTION_WORDS[language];
+  return categories.map((cat) => `- ${cat.label}: ${cat.words.join(', ')}`).join('\n');
+}

--- a/src/services/llm/llm-service.ts
+++ b/src/services/llm/llm-service.ts
@@ -9,6 +9,7 @@ import {
 } from './message-history.js';
 import { createOllamaProvider } from './ollama-provider.js';
 import {
+  type ReactionPromptOptions,
   createChatMessages,
   createReactionPrompt,
   createReflectionPrompt,
@@ -56,7 +57,7 @@ export interface LLMServiceInterface {
   ): AsyncIterable<StreamChunk>;
   summarize(entries: string[]): Promise<ChatResponse>;
   reflect(entry: string): Promise<ChatResponse>;
-  react(entry: string): Promise<ChatResponse>;
+  react(entry: string, options?: ReactionPromptOptions): Promise<ChatResponse>;
   healthCheck(): Promise<{ primary: boolean; fallback?: boolean }>;
   clearHistory(sessionId?: string): void;
   getProviderInfo(): { provider: Provider; model: string };
@@ -191,8 +192,8 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
     }
   };
 
-  const react = async (entry: string): Promise<ChatResponse> => {
-    const messages = createReactionPrompt(entry);
+  const react = async (entry: string, options?: ReactionPromptOptions): Promise<ChatResponse> => {
+    const messages = createReactionPrompt(entry, options);
 
     try {
       return await primaryProvider.chat(messages);
@@ -264,8 +265,8 @@ export class LLMService implements LLMServiceInterface {
   reflect(entry: string) {
     return this._service.reflect(entry);
   }
-  react(entry: string) {
-    return this._service.react(entry);
+  react(entry: string, options?: ReactionPromptOptions) {
+    return this._service.react(entry, options);
   }
   healthCheck() {
     return this._service.healthCheck();

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -4,6 +4,8 @@
  * Core concept: "A place to throw your mumbles, with AI just being there"
  * Inspired by: Future, mumble rap, Freebandz, Pluto
  */
+import type { DetectedLanguage } from '../language/types.js';
+import { getWordListForLanguage } from '../language/word-lists.js';
 import type { Message } from './types.js';
 
 /**
@@ -123,22 +125,56 @@ Bad: "It sounds like you're processing a lot. What do you think is driving these
   ];
 }
 
+export interface ReactionPromptOptions {
+  language?: DetectedLanguage;
+}
+
 /**
  * Create a reaction prompt for a journal entry
  * This produces minimal, mumbl-style reactions
  */
-export function createReactionPrompt(entry: string): Message[] {
+export function createReactionPrompt(entry: string, options?: ReactionPromptOptions): Message[] {
+  const language = options?.language;
+  const wordList = language ? getWordListForLanguage(language) : getWordListForLanguage('en');
+
+  const styleLabel = language === 'ja' ? 'Romanized Japanese slang style' : 'Rapper slang style';
+
+  const examples =
+    language === 'ja'
+      ? `Examples:
+"work is tough" -> tsura
+"had coffee" -> \u00B7
+"can't sleep" -> yaba
+"today was okay" -> sou
+"kids look happy" -> ii-ne
+"tired" -> wakaru
+"crazy" -> maji
+"home" -> \u00B7
+"ate food" -> \u00B7
+"project done" -> saikou
+"same thing again" -> sore-na
+"nice weather" -> yoi`
+      : `Examples:
+"work is tough" -> rough
+"had coffee" -> \u00B7
+"can't sleep" -> bruh
+"today was okay" -> aight
+"kids look happy" -> dope
+"tired" -> felt
+"crazy" -> sheesh
+"home" -> \u00B7
+"ate food" -> \u00B7
+"project done" -> fire
+"same thing again" -> bruh
+"nice weather" -> valid`;
+
   return [
     {
       role: 'system',
-      content: `You respond with ONE word only. Rapper slang style. Curt and distant. Vary your responses.
+      content: `You respond with ONE word only. ${styleLabel}. Curt and distant. Vary your responses.
 
 Word options (pick different ones each time):
-- Acknowledgment: bet, word, aight, cool, k, yo, yea, uh-huh
-- Negative/tough: damn, oof, rough, bruh, yikes, sheesh, nah
-- Positive vibes: lit, fire, dope, nice, sick, tight, valid
-- Feeling it: fr, real, facts, mood, felt, same, true
-- Neutral: ·
+${wordList}
 
 NEVER use:
 - Full sentences
@@ -146,19 +182,7 @@ NEVER use:
 - Questions
 - Emojis
 
-Examples:
-"仕事つらい" -> rough
-"コーヒー飲んだ" -> ·
-"眠れない" -> bruh
-"今日はまあまあ" -> aight
-"子供が楽しそう" -> dope
-"疲れた" -> felt
-"やばい" -> sheesh
-"帰宅" -> ·
-"ごはん食べた" -> ·
-"プロジェクト終わった" -> fire
-"また同じこと" -> bruh
-"いい天気" -> valid`,
+${examples}`,
     },
     {
       role: 'user',

--- a/src/services/reaction-service.test.ts
+++ b/src/services/reaction-service.test.ts
@@ -165,7 +165,9 @@ describe('ReactionService', () => {
 
       const reaction = await llmService.generateReaction('entry-1', 'work is killing me');
 
-      expect(mockLLMService.react).toHaveBeenCalledWith('work is killing me');
+      expect(mockLLMService.react).toHaveBeenCalledWith('work is killing me', {
+        language: 'en',
+      });
       expect(reaction?.content).toBe("that's rough");
       expect(reaction?.reactionType).toBe('custom');
     });

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -2,12 +2,15 @@ import type { Database as DatabaseType } from 'better-sqlite3';
 import { createReactionRepository } from '../repositories/reaction-repository.js';
 import type { Reaction, ReactionType } from '../repositories/types.js';
 import { generateEntryId } from './id-service.js';
+import { detectLanguage } from './language/detect.js';
+import type { DetectedLanguage } from './language/types.js';
 import type { LLMServiceInterface } from './llm/llm-service.js';
 
 export interface ReactionConfig {
   enabled: boolean;
   defaultReactionType: ReactionType;
   useLLM: boolean;
+  language?: 'auto' | 'ja' | 'en';
 }
 
 /**
@@ -103,6 +106,14 @@ export function createReactionService(
     return currentConfig.enabled;
   };
 
+  const resolveLanguage = (content: string): DetectedLanguage | undefined => {
+    const mode = currentConfig.language;
+    if (!mode || mode === 'auto') {
+      return detectLanguage(content);
+    }
+    return mode;
+  };
+
   const generateReaction = async (entryId: string, content: string): Promise<Reaction | null> => {
     if (!currentConfig.enabled) {
       return null;
@@ -113,7 +124,8 @@ export function createReactionService(
 
     if (currentConfig.useLLM && llmService) {
       try {
-        const response = await llmService.react(content);
+        const language = resolveLanguage(content);
+        const response = await llmService.react(content, { language });
         const trimmed = response.content.trim();
         // Use LLM response if non-empty, otherwise fallback
         if (trimmed) {


### PR DESCRIPTION
## Summary

Implements issue #86 by adding Japanese/English language detection for reaction word selection.

- Unicode character range analysis detects CJK content
- Language-matched reaction words (Japanese or English slang)
- Configurable via `MUMBL_REACTION_LANGUAGE` env var (auto/ja/en)

## Changes

- **src/services/language/detect.ts**: Unicode range-based language detection
- **src/services/language/word-lists.ts**: Japanese and English reaction word lists by category
- **src/services/language/types.ts**: DetectedLanguage type and config types
- **src/services/llm/prompts.ts**: createReactionPrompt accepts language option
- **src/services/llm/llm-service.ts**: react() passes language through
- **src/services/reaction-service.ts**: Detects language before LLM call
- **src/infrastructure/config/reaction-config.ts**: MUMBL_REACTION_LANGUAGE parsing

## Test plan

- [x] pnpm type-check passes
- [x] pnpm lint passes
- [x] pnpm test passes (413 tests, 30 files)
- [x] Backward compatible: default auto mode uses English for English content
- [x] Japanese detection works for hiragana, katakana, kanji, mixed content