### PR TITLE
Change first view to write mode and reverse list order

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -79,9 +79,7 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
 
   // Resolve -1 sentinel to last entry index
   const resolvedInitialIndex =
-    listState.selectedIndex === -1 && entryItems.length > 0
-      ? entryItems.length - 1
-      : listState.selectedIndex;
+    listState.selectedIndex === -1 && entryItems.length > 0 ? 0 : listState.selectedIndex;
 
   const { selectedIndex, setSelectedIndex } = useKeyboardNavigation({
     itemCount: entryItems.length,
@@ -101,9 +99,8 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // When entries load and sentinel was set, update to last entry
   useEffect(() => {
     if (listState.selectedIndex === -1 && entryItems.length > 0) {
-      const lastIndex = entryItems.length - 1;
-      setSelectedIndex(lastIndex);
-      setListState({ selectedIndex: lastIndex });
+      setSelectedIndex(0);
+      setListState({ selectedIndex: 0 });
     }
   }, [listState.selectedIndex, entryItems.length, setSelectedIndex, setListState]);
 

--- a/src/ui/context/NavigationContext.test.tsx
+++ b/src/ui/context/NavigationContext.test.tsx
@@ -23,14 +23,14 @@ function ModeDisplayComponent() {
 }
 
 describe('NavigationContext', () => {
-  it('should provide default mode as list', () => {
+  it('should provide default mode as write', () => {
     const { lastFrame } = render(
       <NavigationProvider>
         <TestComponent />
       </NavigationProvider>,
     );
 
-    expect(lastFrame()).toContain('mode:list');
+    expect(lastFrame()).toContain('mode:write');
   });
 
   it('should allow setting initial mode', () => {

--- a/src/ui/context/NavigationContext.tsx
+++ b/src/ui/context/NavigationContext.tsx
@@ -41,7 +41,7 @@ interface NavigationProviderProps {
   initialMode?: AppMode;
 }
 
-export function NavigationProvider({ children, initialMode = 'list' }: NavigationProviderProps) {
+export function NavigationProvider({ children, initialMode = 'write' }: NavigationProviderProps) {
   const [mode, setMode] = useState<AppMode>(initialMode);
   const [listState, setListState] = useState<ListState>({ selectedIndex: 0 });
   const [writeState, setWriteState] = useState<WriteState>({ content: '' });

--- a/src/ui/hooks/useEntries.ts
+++ b/src/ui/hooks/useEntries.ts
@@ -29,7 +29,7 @@ export function useEntries(options: UseEntriesOptions = {}): UseEntriesResult {
       const listOptions: ListEntriesOptions = {
         limit: options.limit,
         sortBy: options.sortBy ?? 'timestamp',
-        order: options.order ?? 'asc',
+        order: options.order ?? 'desc',
       };
 
       const result = entryService.list(listOptions);

--- a/src/ui/utils/date-formatter.test.ts
+++ b/src/ui/utils/date-formatter.test.ts
@@ -85,13 +85,13 @@ describe('groupEntriesByDate', () => {
     const grouped = groupEntriesByDate(entries, now);
 
     expect(grouped).toHaveLength(3);
-    // Groups are ordered oldest first for chat-style display
-    expect(grouped[0].group).toBe('older');
-    expect(grouped[0].entries).toHaveLength(1);
+    // Groups are ordered newest first
+    expect(grouped[0].group).toBe('today');
+    expect(grouped[0].entries).toHaveLength(2);
     expect(grouped[1].group).toBe('yesterday');
     expect(grouped[1].entries).toHaveLength(1);
-    expect(grouped[2].group).toBe('today');
-    expect(grouped[2].entries).toHaveLength(2);
+    expect(grouped[2].group).toBe('older');
+    expect(grouped[2].entries).toHaveLength(1);
   });
 
   it('should maintain entry order within groups', () => {

--- a/src/ui/utils/date-formatter.ts
+++ b/src/ui/utils/date-formatter.ts
@@ -107,14 +107,14 @@ export function groupEntriesByDate(
     groups.set(group, existing);
   }
 
-  // Return groups in chronological order (oldest first for chat-style display)
+  // Return groups in reverse chronological order (newest first)
   const groupOrder: DateGroup[] = [
-    'older',
-    'thisMonth',
-    'lastWeek',
-    'thisWeek',
-    'yesterday',
     'today',
+    'yesterday',
+    'thisWeek',
+    'lastWeek',
+    'thisMonth',
+    'older',
   ];
 
   return groupOrder


### PR DESCRIPTION
## Summary

Implements issue #108 with two UX improvements:

- Change startup first view from list mode to write mode
- Reverse list ordering to show newest entries at the top (descending)

## Changes

- **src/ui/context/NavigationContext.tsx**: Change `initialMode` default from `list` to `write`
- **src/ui/hooks/useEntries.ts**: Change default sort `order` from `asc` to `desc`
- **src/ui/utils/date-formatter.ts**: Reverse date group order (Today first, Older last)
- **src/ui/components/entries/EntryList.tsx**: Fix select-newest-entry sentinel to resolve to index 0
- **src/ui/context/NavigationContext.test.tsx**: Update test for new default mode
- **src/ui/utils/date-formatter.test.ts**: Update test for new group order

## Test plan

- [ ] App starts in write mode after splash screen
- [ ] Pressing Tab switches to list mode with newest entries at the top
- [ ] Date groups ordered: Today → Yesterday → This Week → Last Week → This Month → Older
- [ ] Writing a new entry returns to list with the new entry selected at the top
- [ ] All unit tests pass