### PR TITLE
Fix config file to support wordgrainDir setting

### DIFF
--- a/src/config/config-file.test.ts
+++ b/src/config/config-file.test.ts
@@ -53,6 +53,22 @@ describe('config-file', () => {
       expect(result.baseUrl).toBe('http://localhost:8080');
     });
 
+    it('should parse valid config file with wordgrainDir', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ wordgrainDir: '/custom/wordgrain' }),
+      );
+      const result = loadConfigFile();
+      expect(result.wordgrainDir).toBe('/custom/wordgrain');
+    });
+
+    it('should ignore non-string wordgrainDir values', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainDir: 123 }));
+      const result = loadConfigFile();
+      expect(result.wordgrainDir).toBeUndefined();
+    });
+
     it('should parse valid config file with all fields', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
@@ -60,12 +76,14 @@ describe('config-file', () => {
           model: 'gpt-4',
           provider: 'anthropic',
           baseUrl: 'http://localhost:8080',
+          wordgrainDir: '/custom/wordgrain',
         }),
       );
       const result = loadConfigFile();
       expect(result.model).toBe('gpt-4');
       expect(result.provider).toBe('anthropic');
       expect(result.baseUrl).toBe('http://localhost:8080');
+      expect(result.wordgrainDir).toBe('/custom/wordgrain');
     });
 
     it('should return empty object for malformed JSON', () => {

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -51,6 +51,10 @@ export function loadConfigFile(): Partial<MumblConfig> {
       result.baseUrl = config['baseUrl'];
     }
 
+    if (typeof config['wordgrainDir'] === 'string') {
+      result.wordgrainDir = config['wordgrainDir'];
+    }
+
     return result;
   } catch {
     // Silently ignore config file errors (missing, malformed JSON)


### PR DESCRIPTION
## Summary

Fixes #110 — `loadConfigFile()` now reads `wordgrainDir` from `~/.config/mumbl/config.json`.

- Add `wordgrainDir` extraction to `loadConfigFile()` following the existing pattern
- Add tests for valid string, non-string rejection, and all-fields parsing

## Changes

- **src/config/config-file.ts**: Add `wordgrainDir` string check and assignment after `baseUrl` block
- **src/config/config-file.test.ts**: Add 2 new test cases, update 1 existing test

## Test plan

- [x] `pnpm test:unit src/config/config-file.test.ts` — 16 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean