### PR TITLE
Fix layout shift when reactions appear in entry list

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -119,16 +119,16 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // Calculate viewport height: terminal rows - header (2 lines) - padding (2 lines) - footer reserve (3 lines)
   const viewportHeight = Math.max(5, terminalRows - 7);
 
-  // Calculate item heights: entries with reactions = 2 lines, headers = 3 lines, entries without reactions = 1 line
+  // Calculate item heights: entries = 2 lines (always reserve space for reaction), headers = 3 lines
   const itemHeights = useMemo(() => {
     return flatList.map((item) => {
       if (item.type === 'header') {
         return 3; // 1 line content + marginY={1} (1 above + 1 below)
       }
-      // Entry with reaction takes 2 lines, without reaction takes 1 line
-      return reactions.has(item.entry.id) ? 2 : 1;
+      // Always 2 lines: content + reaction area (prevents layout shift)
+      return 2;
     });
-  }, [flatList, reactions]);
+  }, [flatList]);
 
   // Use scrollable list hook for scroll management with variable item heights
   const { visibleStartIndex, visibleEndIndex, hasItemsAbove, hasItemsBelow } = useScrollableList({

--- a/src/ui/components/entries/EntryListItem.tsx
+++ b/src/ui/components/entries/EntryListItem.tsx
@@ -48,13 +48,11 @@ export function EntryListItem({ entry, isSelected, maxWidth = 60, reaction }: En
         <Text>{padding}</Text>
         <Text dimColor>{timestamp}</Text>
       </Box>
-      {/* Second line: reaction (if exists) */}
-      {reaction && (
-        <Box>
-          <Text>{'  '}</Text>
-          <Text dimColor>{formatReactionDisplay(reaction)}</Text>
-        </Box>
-      )}
+      {/* Second line: reaction area (always rendered to prevent layout shift) */}
+      <Box>
+        <Text>{'  '}</Text>
+        <Text dimColor>{reaction ? formatReactionDisplay(reaction) : ' '}</Text>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #111 - Entry items now always reserve 2 lines of height, preventing layout shift when reactions arrive asynchronously from the LLM.

- Always return height 2 for entry items in scroll calculation
- Always render reaction area (empty space when no reaction exists)
- Remove unnecessary `reactions` dependency from `itemHeights` useMemo

## Changes

- **EntryList.tsx**: `itemHeights` always returns 2 for entries, removed `reactions` from useMemo deps
- **EntryListItem.tsx**: Reaction area always rendered, shows empty space when no reaction

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 679 unit tests pass
- [ ] Visual verification: entries without reactions show consistent 2-line height
- [ ] Visual verification: no layout shift when reaction arrives after entry is displayed