### PR TITLE
Fix Japanese reaction bias toward tsura

### DIFF
--- a/src/services/language/word-lists.ts
+++ b/src/services/language/word-lists.ts
@@ -21,7 +21,7 @@ export const REACTION_WORDS: Record<DetectedLanguage, WordCategory[]> = {
   ],
   ja: [
     { label: 'Acknowledgment', words: ['な', 'うん', 'そう', 'おけ', 'はい', 'あぁ', 'んん'] },
-    { label: 'Negative/tough', words: ['つら', 'やば', 'うわ', 'げ', 'マジ', '俺も', 'いた'] },
+    { label: 'Negative/tough', words: ['やば', 'うわ', 'げ', 'つら', 'マジ', '俺も', 'いた'] },
     {
       label: 'Positive vibes',
       words: ['いい', 'よい', '最高', '神', 'よし', 'いいね', 'ないすー'],

--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -6,6 +6,7 @@ import {
   createChatMessages,
   createFollowUpEvaluationPrompt,
   createFollowUpPrompt,
+  createReactionPrompt,
   createReflectionPrompt,
   createSummaryPrompt,
 } from './prompts.js';
@@ -215,6 +216,61 @@ describe('createCalloutPrompt', () => {
     expect(messages[0]?.content).toContain('Vocabulary Reference');
     expect(messages[0]?.content).toContain('vibe');
     expect(messages[0]?.content).toContain('on god');
+  });
+});
+
+describe('createReactionPrompt', () => {
+  it('should create messages with system and user roles', () => {
+    const messages = createReactionPrompt('feeling tired');
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.role).toBe('system');
+    expect(messages[1]?.role).toBe('user');
+    expect(messages[1]?.content).toBe('feeling tired');
+  });
+
+  it('should use Japanese examples with Japanese input text for ja language', () => {
+    const messages = createReactionPrompt('疲れた', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Japanese slang style');
+    expect(systemContent).toContain('仕事だるい');
+    expect(systemContent).toContain('コーヒー飲んだ');
+    expect(systemContent).toContain('眠れない');
+    expect(systemContent).not.toContain('"work is tough"');
+    expect(systemContent).not.toContain('"had coffee"');
+  });
+
+  it('should not have tsura as first example mapping for ja language', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+    const examplesStart = systemContent.indexOf('Examples:');
+    const firstMapping = systemContent.slice(examplesStart, examplesStart + 100);
+
+    expect(firstMapping).not.toContain('-> つら');
+  });
+
+  it('should use English examples for en language', () => {
+    const messages = createReactionPrompt('test', { language: 'en' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Rapper slang style');
+    expect(systemContent).toContain('"work is tough"');
+  });
+
+  it('should include variation instruction', () => {
+    const messages = createReactionPrompt('test');
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('never repeat the same word for different entries');
+    expect(systemContent).toContain('spread across all categories');
+  });
+
+  it('should include vocabulary when provided', () => {
+    const messages = createReactionPrompt('test', undefined, testVocabulary);
+
+    expect(messages[0]?.content).toContain('Vocabulary Reference');
+    expect(messages[0]?.content).toContain('vibe');
   });
 });
 

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -22,7 +22,7 @@ const MUMBL_BASE_PROMPT = `You are mumbl. A presence that receives mumbles.
 - No pressure, no judgment (freebandz)
 
 ## Response Style
-- Keep it minimal. 1-2 sentences max.
+- Keep it minimal. Regularly within 5 sentences max. 1-2 sentences is usual.
 - No lectures, no advice, no solutions
 - Just acknowledge. Just hear.
 - Match their energy - if they're brief, you're brief
@@ -198,18 +198,18 @@ export function createReactionPrompt(
   const examples =
     language === 'ja'
       ? `Examples:
-"work is tough" -> つら
-"had coffee" -> \u00B7
-"can't sleep" -> やば
-"today was okay" -> そう
-"kids look happy" -> いいね
-"tired" -> わかる
-"crazy" -> マジ
-"home" -> \u00B7
-"ate food" -> \u00B7
-"project done" -> 最高
-"same thing again" -> それな
-"nice weather" -> よい`
+"仕事だるい" -> やば
+"コーヒー飲んだ" -> \u00B7
+"眠れない" -> うわ
+"今日まあまあだった" -> そう
+"子供たち楽しそう" -> いいね
+"疲れた" -> な
+"やばくない？" -> マジ
+"帰った" -> \u00B7
+"ご飯食べた" -> \u00B7
+"プロジェクト終わった" -> 最高
+"また同じこと" -> それな
+"天気いい" -> よい`
       : `Examples:
 "work is tough" -> rough
 "had coffee" -> \u00B7
@@ -225,9 +225,9 @@ export function createReactionPrompt(
 "nice weather" -> valid`;
 
   return createPromptPair(
-    `You respond with ONE word only. ${styleLabel}. Curt and distant. Vary your responses.
+    `You respond with ONE word only. ${styleLabel}. Curt and distant. Vary your responses - never repeat the same word for different entries.
 
-Word options (pick different ones each time):
+Word options (spread across all categories, not just one):
 ${wordList}
 
 NEVER use:


### PR DESCRIPTION
## Summary

Fixes issue #113. Japanese journal entries disproportionately received the `つら` reaction regardless of content sentiment due to English-language examples, first-position bias, and weak variation enforcement.

- Replace English input text in Japanese reaction examples with Japanese text
- Remove `つら` from examples and reorder word list to reduce first-position bias
- Strengthen variation instructions to encourage category spread

## Changes

- **src/services/llm/prompts.ts**: Use Japanese input examples (`"仕事だるい"`, `"コーヒー飲んだ"`, etc.), remove `つら` from example mappings, add `な` (acknowledgment) for neutral entries, strengthen variation and category-spread instructions
- **src/services/language/word-lists.ts**: Reorder Japanese Negative/tough category — `つら` moved from position 1 to position 4
- **src/services/llm/prompts.test.ts**: Add `createReactionPrompt` test suite (6 tests) covering Japanese examples, first-position bias, English fallback, variation instructions, and vocabulary injection

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm ci:check` (lint + format) passes
- [x] All tests pass (41 tests including 6 new ones)
- [ ] Manual: verify `createReactionPrompt("疲れた", { language: 'ja' })` produces diverse reactions