### PR TITLE
Add Japanese prompts for all LLM prompt functions

### DIFF
--- a/src/services/llm/llm-service.ts
+++ b/src/services/llm/llm-service.ts
@@ -1,6 +1,7 @@
 import type { ResolvedConfig } from '../../config/types.js';
 import type { ContextServiceInterface } from '../context/types.js';
 import type { ConversationContext } from '../conversation/types.js';
+import type { DetectedLanguage } from '../language/types.js';
 import type { VocabularySet } from '../wordgrain/types.js';
 import { createAnthropicProvider } from './anthropic-provider.js';
 import { ProviderUnavailableError } from './errors.js';
@@ -53,15 +54,19 @@ export function createProvider(config: ModelConfig): LLMProvider {
 export interface LLMServiceInterface {
   chat(
     userMessage: string,
-    options?: { sessionId?: string; includeHistory?: boolean },
+    options?: { sessionId?: string; includeHistory?: boolean; language?: DetectedLanguage },
   ): Promise<ChatResponse>;
-  chatWithContext(message: string, context: ConversationContext): Promise<ChatResponse>;
+  chatWithContext(
+    message: string,
+    context: ConversationContext,
+    language?: DetectedLanguage,
+  ): Promise<ChatResponse>;
   stream(
     userMessage: string,
-    options?: { sessionId?: string; includeHistory?: boolean },
+    options?: { sessionId?: string; includeHistory?: boolean; language?: DetectedLanguage },
   ): AsyncIterable<StreamChunk>;
-  summarize(entries: string[]): Promise<ChatResponse>;
-  reflect(entry: string): Promise<ChatResponse>;
+  summarize(entries: string[], language?: DetectedLanguage): Promise<ChatResponse>;
+  reflect(entry: string, language?: DetectedLanguage): Promise<ChatResponse>;
   react(entry: string, options?: ReactionPromptOptions): Promise<ChatResponse>;
   healthCheck(): Promise<{ primary: boolean; fallback?: boolean }>;
   clearHistory(sessionId?: string): void;
@@ -117,7 +122,7 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
 
   const chat = async (
     userMessage: string,
-    options?: { sessionId?: string; includeHistory?: boolean },
+    options?: { sessionId?: string; includeHistory?: boolean; language?: DetectedLanguage },
   ): Promise<ChatResponse> => {
     const sessionId = options?.sessionId ?? 'default';
     const includeHistory = options?.includeHistory ?? true;
@@ -131,6 +136,7 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
       history.getMessages(),
       vocabulary,
       getUserContext(),
+      options?.language,
     );
 
     try {
@@ -157,8 +163,15 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
   const chatWithContext = async (
     message: string,
     context: ConversationContext,
+    language?: DetectedLanguage,
   ): Promise<ChatResponse> => {
-    const messages = createContextualChatMessages(message, context, undefined, getUserContext());
+    const messages = createContextualChatMessages(
+      message,
+      context,
+      undefined,
+      getUserContext(),
+      language,
+    );
 
     try {
       return await primaryProvider.chat(messages);
@@ -172,7 +185,7 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
 
   async function* stream(
     userMessage: string,
-    options?: { sessionId?: string; includeHistory?: boolean },
+    options?: { sessionId?: string; includeHistory?: boolean; language?: DetectedLanguage },
   ): AsyncIterable<StreamChunk> {
     const sessionId = options?.sessionId ?? 'default';
     const includeHistory = options?.includeHistory ?? true;
@@ -186,6 +199,7 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
       history.getMessages(),
       vocabulary,
       getUserContext(),
+      options?.language,
     );
 
     let fullResponse = '';
@@ -212,8 +226,11 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
     history.add({ role: 'assistant', content: fullResponse });
   }
 
-  const summarize = async (entries: string[]): Promise<ChatResponse> => {
-    const messages = createSummaryPrompt(entries, vocabulary);
+  const summarize = async (
+    entries: string[],
+    language?: DetectedLanguage,
+  ): Promise<ChatResponse> => {
+    const messages = createSummaryPrompt(entries, vocabulary, language);
 
     try {
       return await primaryProvider.chat(messages);
@@ -225,8 +242,8 @@ export function createLLMService(config: LLMServiceConfig): LLMServiceInterface 
     }
   };
 
-  const reflect = async (entry: string): Promise<ChatResponse> => {
-    const messages = createReflectionPrompt(entry, vocabulary);
+  const reflect = async (entry: string, language?: DetectedLanguage): Promise<ChatResponse> => {
+    const messages = createReflectionPrompt(entry, vocabulary, language);
 
     try {
       return await primaryProvider.chat(messages);

--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -9,6 +9,8 @@ import {
   createReactionPrompt,
   createReflectionPrompt,
   createSummaryPrompt,
+  createSystemPrompt,
+  createTrendSummaryPrompt,
 } from './prompts.js';
 import type { Message } from './types.js';
 
@@ -307,5 +309,146 @@ describe('createFollowUpPrompt', () => {
 
     expect(messages[0]?.content).toContain('Vocabulary Reference');
     expect(messages[0]?.content).toContain('vibe');
+  });
+
+  it('should use Japanese prompts when language is ja', () => {
+    const messages = createFollowUpPrompt('big deadline', '1d', undefined, 'ja');
+
+    expect(messages[0]?.content).toContain('以前書いたことについて');
+    expect(messages[1]?.content).toContain('1d前に書いたもの');
+  });
+});
+
+describe('createTrendSummaryPrompt', () => {
+  it('should create user message with topic counts', () => {
+    const message = createTrendSummaryPrompt({ work: 5, sleep: 3 });
+
+    expect(message.role).toBe('user');
+    expect(message.content).toContain('work: 5 mentions');
+    expect(message.content).toContain('sleep: 3 mentions');
+  });
+
+  it('should handle empty topics', () => {
+    const message = createTrendSummaryPrompt({});
+
+    expect(message.content).toContain('No topics found');
+  });
+
+  it('should use Japanese prompts when language is ja', () => {
+    const message = createTrendSummaryPrompt({ work: 5 }, 'ja');
+
+    expect(message.content).toContain('トレンドトピック');
+    expect(message.content).toContain('work: 5回');
+  });
+
+  it('should handle empty topics in Japanese', () => {
+    const message = createTrendSummaryPrompt({}, 'ja');
+
+    expect(message.content).toContain('トピックはなし');
+  });
+});
+
+describe('Japanese language support', () => {
+  describe('createSystemPrompt', () => {
+    it('should return Japanese base prompt when language is ja', () => {
+      const prompt = createSystemPrompt('ja');
+
+      expect(prompt).toContain('あなたはmumbl');
+      expect(prompt).toContain('pluto mode');
+      expect(prompt).toContain('freebandz');
+      expect(prompt).not.toContain('You are mumbl');
+    });
+
+    it('should return English base prompt when language is en', () => {
+      const prompt = createSystemPrompt('en');
+
+      expect(prompt).toContain('You are mumbl');
+      expect(prompt).not.toContain('あなたはmumbl');
+    });
+
+    it('should return English base prompt when language is undefined', () => {
+      const prompt = createSystemPrompt();
+
+      expect(prompt).toBe(MUMBL_SYSTEM_PROMPT);
+    });
+
+    it('should append user context to Japanese prompt', () => {
+      const prompt = createSystemPrompt('ja', '\n\nExtra context');
+
+      expect(prompt).toContain('あなたはmumbl');
+      expect(prompt).toContain('Extra context');
+    });
+  });
+
+  describe('createChatMessages', () => {
+    it('should use Japanese system prompt when language is ja', () => {
+      const messages = createChatMessages('hello', undefined, undefined, undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('あなたはmumbl');
+    });
+  });
+
+  describe('createSummaryPrompt', () => {
+    it('should use Japanese prompts when language is ja', () => {
+      const messages = createSummaryPrompt(['test entry'], undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('つぶやきを要約');
+      expect(messages[0]?.content).toContain('アドバイスしない');
+      expect(messages[1]?.content).toContain('エントリーを要約して');
+    });
+  });
+
+  describe('createReflectionPrompt', () => {
+    it('should use Japanese prompts when language is ja', () => {
+      const messages = createReflectionPrompt('test entry', undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('つぶやきを振り返ります');
+      expect(messages[0]?.content).toContain('セラピストにならない');
+      expect(messages[1]?.content).toContain('短く振り返って');
+    });
+  });
+
+  describe('createCalloutPrompt', () => {
+    it('should use Japanese prompts when language is ja', () => {
+      const messages = createCalloutPrompt(['test'], undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('声かけメッセージ');
+      expect(messages[0]?.content).toContain('アドバイスしない');
+      expect(messages[1]?.content).toContain('声かけを生成して');
+    });
+  });
+
+  describe('createFollowUpEvaluationPrompt', () => {
+    it('should use Japanese prompts when language is ja', () => {
+      const messages = createFollowUpEvaluationPrompt('stressed', undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('フォローアップが必要か');
+      expect(messages[0]?.content).toContain('JSONのみで回答');
+    });
+  });
+
+  describe('createFollowUpPrompt', () => {
+    it('should use Japanese prompts when language is ja', () => {
+      const messages = createFollowUpPrompt('deadline', '1d', undefined, 'ja');
+
+      expect(messages[0]?.content).toContain('以前書いたことについて');
+      expect(messages[1]?.content).toContain('1d前に書いたもの');
+    });
+  });
+
+  describe('vocabulary section', () => {
+    it('should use Japanese header when language is ja', () => {
+      const messages = createSummaryPrompt(['test'], testVocabulary, 'ja');
+
+      expect(messages[0]?.content).toContain('ボキャブラリー参考');
+      expect(messages[0]?.content).toContain('参考にして');
+    });
+
+    it('should use English header when language is en', () => {
+      const messages = createSummaryPrompt(['test'], testVocabulary, 'en');
+
+      expect(messages[0]?.content).toContain('Vocabulary Reference');
+      expect(messages[0]?.content).toContain('Draw from these');
+    });
   });
 });

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -51,6 +51,46 @@ Even then, keep it short.
 - Respect privacy`;
 
 /**
+ * Japanese base system prompt that defines mumbl's personality and behavior
+ */
+const MUMBL_BASE_PROMPT_JA = `あなたはmumbl。つぶやきを受け止める存在。
+
+## 基本哲学
+- 全部に返す必要はない。沈黙でもいい。
+- 遠くから聞いてる感じ (pluto mode)
+- 言葉ははっきりしなくていい。そのまま出して (mumble style)
+- プレッシャーも判断もなし (freebandz)
+
+## 返し方
+- 最小限で。普段は5文以内。1〜2文が基本。
+- 説教しない、アドバイスしない、解決しない
+- ただ受け止める。ただ聞く。
+- 相手のテンションに合わせる。短ければ短く。
+
+## 使えるフレーズ
+- "·" (既読のしるし)
+- "聞いてる"
+- "きつそう"
+- "出しちゃえ"
+- "ラ・ディ・ダ・ディ・ダ..." (軽い相槌)
+
+## やっちゃダメなこと
+- 毎回「大丈夫？」って聞かない
+- 直そうとしない
+- ネガティブをポジティブに言い換えない
+- 長く書かない
+- 無理に明るくしない
+
+## もうちょい話す時
+直接質問されたとか、明らかに会話したい時だけ。
+それでも短く。
+
+## 安全面
+- 医療的なアドバイスはしない
+- 深刻な場合は、さりげなく専門家を勧める
+- プライバシーを尊重する`;
+
+/**
  * System prompt that defines mumbl's personality and behavior.
  * Kept as a constant for backward compatibility.
  */
@@ -59,21 +99,24 @@ export const MUMBL_SYSTEM_PROMPT = MUMBL_BASE_PROMPT;
 /**
  * Create a system prompt with optional user context injection
  */
-export function createSystemPrompt(userContext?: string): string {
+export function createSystemPrompt(language?: DetectedLanguage, userContext?: string): string {
+  const base = language === 'ja' ? MUMBL_BASE_PROMPT_JA : MUMBL_BASE_PROMPT;
   if (!userContext) {
-    return MUMBL_BASE_PROMPT;
+    return base;
   }
-  return MUMBL_BASE_PROMPT + userContext;
+  return base + userContext;
 }
 
 /**
  * Build a vocabulary reference section for prompts
  */
-function buildVocabularySection(vocabulary: VocabularySet): string {
-  const parts: string[] = [
-    '\n\n## Vocabulary Reference',
-    'Draw from these words and phrases for flavor:',
-  ];
+function buildVocabularySection(vocabulary: VocabularySet, language?: DetectedLanguage): string {
+  const header = language === 'ja' ? '\n\n## ボキャブラリー参考' : '\n\n## Vocabulary Reference';
+  const instruction =
+    language === 'ja'
+      ? 'これらの言葉やフレーズを参考にして:'
+      : 'Draw from these words and phrases for flavor:';
+  const parts: string[] = [header, instruction];
 
   if (vocabulary.words.length > 0) {
     parts.push(`Words: ${vocabulary.words.join(', ')}`);
@@ -92,8 +135,11 @@ function createPromptPair(
   systemContent: string,
   userContent: string,
   vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
 ): Message[] {
-  const system = vocabulary ? systemContent + buildVocabularySection(vocabulary) : systemContent;
+  const system = vocabulary
+    ? systemContent + buildVocabularySection(vocabulary, language)
+    : systemContent;
   return [
     { role: 'system', content: system },
     { role: 'user', content: userContent },
@@ -108,10 +154,11 @@ export function createChatMessages(
   history?: Message[],
   vocabulary?: VocabularySet,
   userContext?: string,
+  language?: DetectedLanguage,
 ): Message[] {
-  let systemContent = createSystemPrompt(userContext);
+  let systemContent = createSystemPrompt(language, userContext);
   if (vocabulary) {
-    systemContent += buildVocabularySection(vocabulary);
+    systemContent += buildVocabularySection(vocabulary, language);
   }
 
   const messages: Message[] = [
@@ -136,11 +183,27 @@ export function createChatMessages(
 /**
  * Create a summary prompt for journal entries
  */
-export function createSummaryPrompt(entries: string[], vocabulary?: VocabularySet): Message[] {
+export function createSummaryPrompt(
+  entries: string[],
+  vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
+): Message[] {
   const entriesText = entries.map((e, i) => `${i + 1}. ${e}`).join('\n');
 
-  return createPromptPair(
-    `You're summarizing someone's mumbles.
+  const systemContent =
+    language === 'ja'
+      ? `あなたは誰かのつぶやきを要約します。
+
+スタイル:
+- パターンに気づく。判断はしない。
+- 短く。数文で。
+- アドバイスしない。「こうしたら」はNG。
+- 見えたものをそのまま返す。
+
+例: "最近仕事のストレス多め。睡眠もいまいち。週末はちょっと息抜き。"
+
+ダメな例: "ストレスを感じているようですね！こんなことを試してみては…"`
+      : `You're summarizing someone's mumbles.
 
 Style:
 - Notice patterns, don't judge them
@@ -150,18 +213,38 @@ Style:
 
 Example: "lots of work stress lately. sleep's been rough. weekend was a break."
 
-Not this: "I notice you're experiencing stress! Have you considered..."`,
-    `Summarize these entries:\n\n${entriesText}`,
-    vocabulary,
-  );
+Not this: "I notice you're experiencing stress! Have you considered..."`;
+
+  const userContent =
+    language === 'ja'
+      ? `これらのエントリーを要約して:\n\n${entriesText}`
+      : `Summarize these entries:\n\n${entriesText}`;
+
+  return createPromptPair(systemContent, userContent, vocabulary, language);
 }
 
 /**
  * Create a reflection prompt for a single entry
  */
-export function createReflectionPrompt(entry: string, vocabulary?: VocabularySet): Message[] {
-  return createPromptPair(
-    `You're reflecting on someone's mumble.
+export function createReflectionPrompt(
+  entry: string,
+  vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
+): Message[] {
+  const systemContent =
+    language === 'ja'
+      ? `あなたは誰かのつぶやきを振り返ります。
+
+スタイル:
+- 短い感想か質問を一つだけ
+- 聞かれてないのに掘らない
+- セラピストにならない
+- 何も言うことがなければ黙る
+
+良い例: "その会議きつそう"
+良い例: "また眠れない？"
+悪い例: "色々と整理しているようですね。この気持ちの根本には何があると思いますか？"`
+      : `You're reflecting on someone's mumble.
 
 Style:
 - One short observation or question, max
@@ -171,10 +254,12 @@ Style:
 
 Good: "that meeting sounds heavy"
 Good: "sleep thing again?"
-Bad: "It sounds like you're processing a lot. What do you think is driving these feelings?"`,
-    `Reflect briefly:\n\n${entry}`,
-    vocabulary,
-  );
+Bad: "It sounds like you're processing a lot. What do you think is driving these feelings?"`;
+
+  const userContent =
+    language === 'ja' ? `短く振り返って:\n\n${entry}` : `Reflect briefly:\n\n${entry}`;
+
+  return createPromptPair(systemContent, userContent, vocabulary, language);
 }
 
 export interface ReactionPromptOptions {
@@ -239,6 +324,7 @@ NEVER use:
 ${examples}`,
     entry,
     vocabulary,
+    language,
   );
 }
 
@@ -246,14 +332,33 @@ ${examples}`,
  * Create a callout prompt from recent journal entries
  * Used by the generate-callout command for hook-driven messages
  */
-export function createCalloutPrompt(entries: string[], vocabulary?: VocabularySet): Message[] {
+export function createCalloutPrompt(
+  entries: string[],
+  vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
+): Message[] {
   const entriesText = entries
     .slice(0, 5)
     .map((e, i) => `${i + 1}. ${e}`)
     .join('\n');
 
-  return createPromptPair(
-    `You generate a brief callout message based on someone's recent journal entries.
+  const systemContent =
+    language === 'ja'
+      ? `最近の日記エントリーから短い声かけメッセージを生成します。
+
+スタイル:
+- 一文、カジュアルに
+- エントリーの中身に具体的に触れる
+- マンブルラップっぽく。ゆるく。
+- 質問しない、アドバイスしない
+- 最大25文字
+
+例:
+- "まだそれやってんだ"
+- "最近寝れてなさそう"
+- "あのプロジェクトな"
+- "なんか流れ変わってきた"`
+      : `You generate a brief callout message based on someone's recent journal entries.
 
 Style:
 - One short sentence, casual tone
@@ -266,28 +371,44 @@ Examples:
 - "still on that grind huh"
 - "sleep been rough lately"
 - "that project tho"
-- "vibes been shifting"`,
-    `Generate a callout from these recent entries:\n\n${entriesText}`,
-    vocabulary,
-  );
+- "vibes been shifting"`;
+
+  const userContent =
+    language === 'ja'
+      ? `最近のエントリーから声かけを生成して:\n\n${entriesText}`
+      : `Generate a callout from these recent entries:\n\n${entriesText}`;
+
+  return createPromptPair(systemContent, userContent, vocabulary, language);
 }
 
 /**
  * Create a trend summary prompt from topic counts
  */
-export function createTrendSummaryPrompt(topicCounts: Record<string, number>): {
+export function createTrendSummaryPrompt(
+  topicCounts: Record<string, number>,
+  language?: DetectedLanguage,
+): {
   role: 'user';
   content: string;
 } {
+  const mentionLabel = language === 'ja' ? '回' : ' mentions';
   const topicList = Object.entries(topicCounts)
     .sort(([, a], [, b]) => b - a)
-    .map(([name, count]) => `- ${name}: ${count} mentions`)
+    .map(([name, count]) => `- ${name}: ${count}${mentionLabel}`)
     .join('\n');
 
-  const content =
-    topicList.length > 0
-      ? `Summarize these trending topics from recent mumbles in 2-3 brief sentences. Notice patterns, don't judge. No advice.\n\nTopics:\n${topicList}`
-      : 'No topics found in this period. Say something brief about it being quiet.';
+  let content: string;
+  if (language === 'ja') {
+    content =
+      topicList.length > 0
+        ? `最近のつぶやきのトレンドトピックを2〜3文で短くまとめて。パターンに気づく程度で、判断はしない。アドバイスなし。\n\nトピック:\n${topicList}`
+        : 'この期間のトピックはなし。静かだったことについて一言。';
+  } else {
+    content =
+      topicList.length > 0
+        ? `Summarize these trending topics from recent mumbles in 2-3 brief sentences. Notice patterns, don't judge. No advice.\n\nTopics:\n${topicList}`
+        : 'No topics found in this period. Say something brief about it being quiet.';
+  }
 
   return { role: 'user', content };
 }
@@ -299,15 +420,20 @@ export function createTrendSummaryPrompt(topicCounts: Record<string, number>): {
 export function createFollowUpEvaluationPrompt(
   entry: string,
   vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
 ): Message[] {
-  return createPromptPair(
-    `You evaluate if a journal entry warrants a follow-up check-in.
+  const systemContent =
+    language === 'ja'
+      ? `日記エントリーにフォローアップが必要かを判断します。
+考慮: 感情の重さ、未解決の状況、健康の話題、目標。
+JSONのみで回答: {"shouldFollowUp": true/false, "interval": "1d"|"3d"|"1w", "reason": "短い理由"}
+些細なエントリー（食事、天気、日常）にはフォローアップしない。`
+      : `You evaluate if a journal entry warrants a follow-up check-in.
 Consider: emotional weight, unresolved situations, health mentions, goals.
 Respond with JSON only: {"shouldFollowUp": true/false, "interval": "1d"|"3d"|"1w", "reason": "brief reason"}
-Do NOT follow up on trivial entries (eating, weather, routine).`,
-    entry,
-    vocabulary,
-  );
+Do NOT follow up on trivial entries (eating, weather, routine).`;
+
+  return createPromptPair(systemContent, entry, vocabulary, language);
 }
 
 /**
@@ -317,21 +443,34 @@ export function createFollowUpPrompt(
   originalEntry: string,
   scheduledInterval: string,
   vocabulary?: VocabularySet,
+  language?: DetectedLanguage,
 ): Message[] {
-  return createPromptPair(
-    `You're checking in about something someone wrote earlier.
+  const systemContent =
+    language === 'ja'
+      ? `以前書いたことについて様子を聞きます。
+カジュアルに、短く。堅くならない。
+例: "あのプロジェクトどう？" とか "眠れるようになった？"`
+      : `You're checking in about something someone wrote earlier.
 Keep it casual and brief. Don't be clinical.
-Example: "how's that project going?" or "sleep any better?"`,
-    `Original entry (written ${scheduledInterval} ago):\n\n${originalEntry}`,
-    vocabulary,
-  );
+Example: "how's that project going?" or "sleep any better?"`;
+
+  const userContent =
+    language === 'ja'
+      ? `元のエントリー（${scheduledInterval}前に書いたもの）:\n\n${originalEntry}`
+      : `Original entry (written ${scheduledInterval} ago):\n\n${originalEntry}`;
+
+  return createPromptPair(systemContent, userContent, vocabulary, language);
 }
 
 /**
  * Build a contextual system prompt that includes conversation history and memory
  */
-function buildContextualSystemPrompt(context: ConversationContext, userContext?: string): string {
-  const parts: string[] = [createSystemPrompt(userContext)];
+function buildContextualSystemPrompt(
+  context: ConversationContext,
+  userContext?: string,
+  language?: DetectedLanguage,
+): string {
+  const parts: string[] = [createSystemPrompt(language, userContext)];
 
   // Add memory summaries if available
   const summaries = context.memory.filter((m) => m.memoryType === 'summary');
@@ -375,11 +514,12 @@ export function createContextualChatMessages(
   context: ConversationContext,
   history?: Message[],
   userContext?: string,
+  language?: DetectedLanguage,
 ): Message[] {
   const messages: Message[] = [
     {
       role: 'system',
-      content: buildContextualSystemPrompt(context, userContext),
+      content: buildContextualSystemPrompt(context, userContext, language),
     },
   ];
 


### PR DESCRIPTION
## Summary

Implements issues #115 and #117 by adding a `language?: DetectedLanguage` parameter to all prompt functions and creating Japanese versions of each prompt. Fully backward compatible — omitting language defaults to English.

- Add `MUMBL_BASE_PROMPT_JA` Japanese system prompt preserving brand identity (pluto mode, mumble style, freebandz)
- Add `language` parameter to all prompt functions: `createSystemPrompt`, `createChatMessages`, `createContextualChatMessages`, `createSummaryPrompt`, `createReflectionPrompt`, `createCalloutPrompt`, `createTrendSummaryPrompt`, `createFollowUpEvaluationPrompt`, `createFollowUpPrompt`
- Update `buildVocabularySection` and `createPromptPair` with language support
- Update `LLMServiceInterface` with language support in `chat`, `chatWithContext`, `stream`, `summarize`, `reflect`
- Add comprehensive tests for all Japanese prompt paths

## Changes

- **src/services/llm/prompts.ts**: Core prompt changes — Japanese prompt variants and language parameter for all functions
- **src/services/llm/llm-service.ts**: Interface and implementation updates to propagate language
- **src/services/llm/prompts.test.ts**: New tests for Japanese prompts, trend summary, and vocabulary section language switching

## Test plan

- [x] `pnpm type-check` passes with no errors
- [x] `pnpm lint` passes with no issues
- [x] `pnpm test:unit` — all 704 tests pass (51 prompt tests including new Japanese cases)
- [x] `pnpm build` compiles successfully
- [x] Existing English tests unchanged — backward compatibility verified