### PR TITLE
Hide wordgrain shortcuts in config mode when wordgrainDir is not configured (#123)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,6 +8,7 @@ import { ConfigView } from './components/config/ConfigView.js';
 import { EntryList } from './components/entries/EntryList.js';
 import { SplashScreen } from './components/splash/SplashScreen.js';
 import { WriteView } from './components/write/WriteView.js';
+import { useConfig } from './context/ConfigContext.js';
 import { NavigationProvider, useNavigation } from './context/NavigationContext.js';
 import { useQueue } from './context/QueueContext.js';
 
@@ -15,6 +16,7 @@ function AppContent() {
   const { exit } = useApp();
   const { mode, toggleMode, switchToConfig } = useNavigation();
   const { status: queueStatus } = useQueue();
+  const { config } = useConfig();
   const [isViewingDetail, setIsViewingDetail] = useState(false);
   const agentStatus = useAgentStatus();
   useTerminalTitle(agentStatus);
@@ -51,7 +53,12 @@ function AppContent() {
         {mode === 'config' && <ConfigView />}
       </Box>
 
-      <HelpFooter mode={mode} isViewingDetail={isViewingDetail} queueStatus={queueStatus} />
+      <HelpFooter
+        mode={mode}
+        isViewingDetail={isViewingDetail}
+        queueStatus={queueStatus}
+        hasWordgrainDir={!!config.wordgrainDir}
+      />
     </Box>
   );
 }

--- a/src/ui/components/common/HelpFooter.test.tsx
+++ b/src/ui/components/common/HelpFooter.test.tsx
@@ -32,12 +32,23 @@ describe('HelpFooter', () => {
     expect(lastFrame()).toContain('Tab: write');
   });
 
-  it('should show config mode shortcuts', () => {
-    const { lastFrame } = render(<HelpFooter mode="config" />);
+  it('should show config mode shortcuts with wordgrain dir', () => {
+    const { lastFrame } = render(<HelpFooter mode="config" hasWordgrainDir={true} />);
 
     expect(lastFrame()).toContain('j/k: navigate');
     expect(lastFrame()).toContain('a: add');
     expect(lastFrame()).toContain('d: delete');
+    expect(lastFrame()).toContain('r: reload');
+    expect(lastFrame()).toContain('Esc: back');
+    expect(lastFrame()).toContain('q: quit');
+  });
+
+  it('should hide wordgrain shortcuts in config mode without wordgrain dir', () => {
+    const { lastFrame } = render(<HelpFooter mode="config" />);
+
+    expect(lastFrame()).not.toContain('j/k: navigate');
+    expect(lastFrame()).not.toContain('a: add');
+    expect(lastFrame()).not.toContain('d: delete');
     expect(lastFrame()).toContain('r: reload');
     expect(lastFrame()).toContain('Esc: back');
     expect(lastFrame()).toContain('q: quit');

--- a/src/ui/components/common/HelpFooter.tsx
+++ b/src/ui/components/common/HelpFooter.tsx
@@ -8,15 +8,24 @@ interface HelpFooterProps {
   mode: AppMode;
   isViewingDetail?: boolean;
   queueStatus?: QueueStatus;
+  hasWordgrainDir?: boolean;
 }
 
-export function HelpFooter({ mode, isViewingDetail = false, queueStatus }: HelpFooterProps) {
+export function HelpFooter({
+  mode,
+  isViewingDetail = false,
+  queueStatus,
+  hasWordgrainDir = false,
+}: HelpFooterProps) {
   const getShortcuts = () => {
     if (mode === 'write') {
       return 'Tab: list | Esc: cancel | q: quit';
     }
     if (mode === 'config') {
-      return 'j/k: navigate | a: add | d: delete | r: reload | Esc: back | q: quit';
+      if (hasWordgrainDir) {
+        return 'j/k: navigate | a: add | d: delete | r: reload | Esc: back | q: quit';
+      }
+      return 'r: reload | Esc: back | q: quit';
     }
     if (isViewingDetail) {
       return 'Esc/q: back | Tab: write';

--- a/src/ui/components/config/ConfigView.tsx
+++ b/src/ui/components/config/ConfigView.tsx
@@ -45,7 +45,7 @@ export function ConfigView() {
         return;
       }
 
-      if (input === 'd' && files.length > 0) {
+      if (input === 'd' && config.wordgrainDir && files.length > 0) {
         setSubMode('delete-confirm');
         return;
       }


### PR DESCRIPTION
## Summary

Hide wordgrain shortcuts in config mode when wordgrainDir is not configured

## Changes

- Hide wordgrain shortcuts in config mode when wordgrainDir is not configured

Resolves #123