### PR TITLE
Replace wordgrainDir with direct file path registration

### DIFF
--- a/src/config/config-file.test.ts
+++ b/src/config/config-file.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getConfigFilePath, loadConfigFile } from './config-file.js';
+import { getConfigFilePath, loadConfigFile, saveConfigFile } from './config-file.js';
 
 vi.mock('node:fs');
 vi.mock('node:os');
@@ -18,8 +19,8 @@ describe('config-file', () => {
 
   describe('getConfigFilePath', () => {
     it('should return correct config file path', () => {
-      const path = getConfigFilePath();
-      expect(path).toBe('/home/user/.config/mumbl/config.json');
+      const configPath = getConfigFilePath();
+      expect(configPath).toBe('/home/user/.config/mumbl/config.json');
     });
   });
 
@@ -53,20 +54,36 @@ describe('config-file', () => {
       expect(result.baseUrl).toBe('http://localhost:8080');
     });
 
-    it('should parse valid config file with wordgrainDir', () => {
+    it('should parse valid config file with wordgrainFiles', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
-        JSON.stringify({ wordgrainDir: '/custom/wordgrain' }),
+        JSON.stringify({ wordgrainFiles: ['/path/to/a.wg.json', '/path/to/b.wg.json'] }),
       );
       const result = loadConfigFile();
-      expect(result.wordgrainDir).toBe('/custom/wordgrain');
+      expect(result.wordgrainFiles).toEqual(['/path/to/a.wg.json', '/path/to/b.wg.json']);
     });
 
-    it('should ignore non-string wordgrainDir values', () => {
+    it('should ignore non-array wordgrainFiles values', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainDir: 123 }));
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainFiles: 'not-array' }));
       const result = loadConfigFile();
-      expect(result.wordgrainDir).toBeUndefined();
+      expect(result.wordgrainFiles).toBeUndefined();
+    });
+
+    it('should filter non-string entries from wordgrainFiles', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ wordgrainFiles: ['/valid.wg.json', 123, null] }),
+      );
+      const result = loadConfigFile();
+      expect(result.wordgrainFiles).toEqual(['/valid.wg.json']);
+    });
+
+    it('should not set wordgrainFiles for empty array after filtering', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainFiles: [123, null] }));
+      const result = loadConfigFile();
+      expect(result.wordgrainFiles).toBeUndefined();
     });
 
     it('should parse valid config file with all fields', () => {
@@ -76,14 +93,14 @@ describe('config-file', () => {
           model: 'gpt-4',
           provider: 'anthropic',
           baseUrl: 'http://localhost:8080',
-          wordgrainDir: '/custom/wordgrain',
+          wordgrainFiles: ['/path/to/vocab.wg.json'],
         }),
       );
       const result = loadConfigFile();
       expect(result.model).toBe('gpt-4');
       expect(result.provider).toBe('anthropic');
       expect(result.baseUrl).toBe('http://localhost:8080');
-      expect(result.wordgrainDir).toBe('/custom/wordgrain');
+      expect(result.wordgrainFiles).toEqual(['/path/to/vocab.wg.json']);
     });
 
     it('should return empty object for malformed JSON', () => {
@@ -142,6 +159,52 @@ describe('config-file', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ provider: 'ollama' }));
       const result = loadConfigFile();
       expect(result.provider).toBe('ollama');
+    });
+  });
+
+  describe('saveConfigFile', () => {
+    it('should create config directory and write file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      saveConfigFile({ wordgrainFiles: ['/path/to/file.wg.json'] });
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(path.join('/home/user', '.config', 'mumbl'), {
+        recursive: true,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const written = JSON.parse((writeCall?.[1] as string).trim());
+      expect(written.wordgrainFiles).toEqual(['/path/to/file.wg.json']);
+    });
+
+    it('should merge with existing config file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ model: 'gpt-4', provider: 'anthropic' }),
+      );
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      saveConfigFile({ wordgrainFiles: ['/path/to/file.wg.json'] });
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const written = JSON.parse((writeCall?.[1] as string).trim());
+      expect(written.model).toBe('gpt-4');
+      expect(written.provider).toBe('anthropic');
+      expect(written.wordgrainFiles).toEqual(['/path/to/file.wg.json']);
+    });
+
+    it('should handle malformed existing config gracefully', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('invalid json');
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      saveConfigFile({ wordgrainFiles: [] });
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const written = JSON.parse((writeCall?.[1] as string).trim());
+      expect(written.wordgrainFiles).toEqual([]);
     });
   });
 });

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -1,7 +1,7 @@
 /**
- * Config file loading for mumbl
+ * Config file loading and saving for mumbl
  *
- * Loads configuration from ~/.config/mumbl/config.json
+ * Loads/saves configuration from/to ~/.config/mumbl/config.json
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -51,8 +51,11 @@ export function loadConfigFile(): Partial<MumblConfig> {
       result.baseUrl = config['baseUrl'];
     }
 
-    if (typeof config['wordgrainDir'] === 'string') {
-      result.wordgrainDir = config['wordgrainDir'];
+    if (Array.isArray(config['wordgrainFiles'])) {
+      const files = config['wordgrainFiles'].filter((f: unknown) => typeof f === 'string');
+      if (files.length > 0) {
+        result.wordgrainFiles = files;
+      }
     }
 
     return result;
@@ -60,4 +63,42 @@ export function loadConfigFile(): Partial<MumblConfig> {
     // Silently ignore config file errors (missing, malformed JSON)
     return {};
   }
+}
+
+/**
+ * Save configuration to config file
+ * Merges the provided partial config with the existing file contents
+ */
+export function saveConfigFile(update: Partial<MumblConfig>): void {
+  const configPath = getConfigFilePath();
+  const configDir = path.dirname(configPath);
+
+  // Ensure config directory exists
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+
+  // Load existing raw config to preserve unknown fields
+  let existing: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const parsed: unknown = JSON.parse(content);
+      if (typeof parsed === 'object' && parsed !== null) {
+        existing = parsed as Record<string, unknown>;
+      }
+    }
+  } catch {
+    // Start fresh if existing file is malformed
+  }
+
+  // Merge update into existing config
+  if (update.model !== undefined) existing['model'] = update.model;
+  if (update.provider !== undefined) existing['provider'] = update.provider;
+  if (update.baseUrl !== undefined) existing['baseUrl'] = update.baseUrl;
+  if (update.wordgrainFiles !== undefined) {
+    existing['wordgrainFiles'] = update.wordgrainFiles;
+  }
+
+  fs.writeFileSync(configPath, `${JSON.stringify(existing, null, 2)}\n`, 'utf-8');
 }

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -6,7 +6,6 @@ import type { Provider } from '../services/llm/types.js';
  * - MUMBL_MODEL: Model name
  * - MUMBL_PROVIDER: Provider name ('ollama' | 'anthropic')
  * - MUMBL_BASE_URL: Base URL for the provider
- * - MUMBL_WORDGRAIN_DIR: Directory containing .wg.json vocabulary files
  * - ANTHROPIC_API_KEY: API key for Anthropic
  */
 import type { MumblConfig } from './types.js';
@@ -31,11 +30,6 @@ export function loadEnvVars(): Partial<MumblConfig> {
   const baseUrl = process.env['MUMBL_BASE_URL'];
   if (baseUrl) {
     result.baseUrl = baseUrl;
-  }
-
-  const wordgrainDir = process.env['MUMBL_WORDGRAIN_DIR'];
-  if (wordgrainDir) {
-    result.wordgrainDir = wordgrainDir;
   }
 
   return result;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,6 @@
  */
 export type { MumblConfig, ResolvedConfig, ConfigSource } from './types.js';
 export { parseCliArgs } from './cli-args.js';
-export { loadConfigFile, getConfigFilePath } from './config-file.js';
+export { loadConfigFile, saveConfigFile, getConfigFilePath } from './config-file.js';
 export { loadEnvVars, getApiKey } from './env-vars.js';
 export { resolveConfig } from './resolve-config.js';

--- a/src/config/resolve-config.ts
+++ b/src/config/resolve-config.ts
@@ -32,14 +32,13 @@ export function resolveConfig(cliArgs?: string[]): ResolvedConfig {
 
   const baseUrl = sources.cli.baseUrl ?? sources.env.baseUrl ?? sources.file.baseUrl;
 
-  const wordgrainDir =
-    sources.cli.wordgrainDir ?? sources.env.wordgrainDir ?? sources.file.wordgrainDir;
+  const wordgrainFiles = sources.file.wordgrainFiles;
 
   return {
     provider,
     model,
     baseUrl,
     apiKey: getApiKey(),
-    wordgrainDir,
+    wordgrainFiles,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,7 +10,7 @@ export interface MumblConfig {
   model?: string;
   provider?: Provider;
   baseUrl?: string;
-  wordgrainDir?: string;
+  wordgrainFiles?: string[];
 }
 
 /**
@@ -21,7 +21,7 @@ export interface ResolvedConfig {
   provider: Provider;
   baseUrl?: string;
   apiKey?: string;
-  wordgrainDir?: string;
+  wordgrainFiles?: string[];
 }
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,8 +50,8 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
   const reactionService = createReactionService(db, reactionConfig, reactionLLMService);
 
   // Load wordgrain vocabulary if configured
-  if (config.wordgrainDir) {
-    const vocabulary = loadVocabulary(config.wordgrainDir);
+  if (config.wordgrainFiles && config.wordgrainFiles.length > 0) {
+    const vocabulary = loadVocabulary(config.wordgrainFiles);
     if (vocabulary) {
       llmService.setVocabulary(vocabulary);
       reactionService.setVocabulary(vocabulary);

--- a/src/services/wordgrain/index.ts
+++ b/src/services/wordgrain/index.ts
@@ -3,26 +3,25 @@
  */
 export type { Grain, VocabularySet, WordgrainFile } from './types.js';
 export { extractVocabulary } from './vocabulary-extractor.js';
-export { loadWordgrainDir, parseWordgrainFile } from './wordgrain-loader.js';
+export { loadWordgrainFiles, parseWordgrainFile } from './wordgrain-loader.js';
 export type { WordgrainFileInfo, WordgrainStats } from './wordgrain-manager.js';
 export {
-  addWordgrainFile,
   getWordgrainStats,
   listWordgrainFiles,
-  removeWordgrainFile,
+  registerWordgrainFile,
 } from './wordgrain-manager.js';
 
 import type { VocabularySet } from './types.js';
 import { extractVocabulary } from './vocabulary-extractor.js';
-import { loadWordgrainDir } from './wordgrain-loader.js';
+import { loadWordgrainFiles } from './wordgrain-loader.js';
 
 /**
- * Load vocabulary from a directory of .wg.json files
- * @param dirPath - Path to directory containing .wg.json files
- * @returns VocabularySet or null if directory is missing or empty
+ * Load vocabulary from individual .wg.json file paths
+ * @param filePaths - Array of paths to .wg.json files
+ * @returns VocabularySet or null if no valid files or vocabulary is empty
  */
-export function loadVocabulary(dirPath: string): VocabularySet | null {
-  const files = loadWordgrainDir(dirPath);
+export function loadVocabulary(filePaths: string[]): VocabularySet | null {
+  const files = loadWordgrainFiles(filePaths);
   if (files.length === 0) return null;
 
   const vocabulary = extractVocabulary(files);

--- a/src/services/wordgrain/wordgrain-loader.test.ts
+++ b/src/services/wordgrain/wordgrain-loader.test.ts
@@ -2,168 +2,178 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { loadWordgrainDir } from './wordgrain-loader.js';
+import { loadWordgrainFiles, parseWordgrainFile } from './wordgrain-loader.js';
 
-describe('loadWordgrainDir', () => {
+describe('parseWordgrainFile', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-test-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-parse-test-'));
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should load valid .wg.json files', () => {
-    const fileContent = JSON.stringify({
-      name: 'test-rapper',
-      grains: [
-        { word: 'drip', tags: ['style'] },
-        { word: 'go hard', context: 'motivation' },
-      ],
-    });
-    fs.writeFileSync(path.join(tmpDir, 'test.wg.json'), fileContent);
-
-    const result = loadWordgrainDir(tmpDir);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('test-rapper');
-    expect(result[0]?.grains).toHaveLength(2);
-    expect(result[0]?.grains[0]?.word).toBe('drip');
-    expect(result[0]?.grains[0]?.tags).toEqual(['style']);
-    expect(result[0]?.grains[1]?.word).toBe('go hard');
-    expect(result[0]?.grains[1]?.context).toBe('motivation');
-  });
-
-  it('should return empty array for missing directory', () => {
-    const result = loadWordgrainDir('/nonexistent/path');
-    expect(result).toEqual([]);
-  });
-
-  it('should return empty array for empty directory', () => {
-    const result = loadWordgrainDir(tmpDir);
-    expect(result).toEqual([]);
-  });
-
-  it('should skip malformed JSON files', () => {
-    fs.writeFileSync(path.join(tmpDir, 'bad.wg.json'), '{ invalid json }');
+  it('should parse a valid .wg.json file', () => {
+    const filePath = path.join(tmpDir, 'test.wg.json');
     fs.writeFileSync(
-      path.join(tmpDir, 'good.wg.json'),
-      JSON.stringify({ name: 'valid', grains: [{ word: 'fire' }] }),
+      filePath,
+      JSON.stringify({
+        name: 'test-rapper',
+        grains: [
+          { word: 'drip', tags: ['style'] },
+          { word: 'go hard', context: 'motivation' },
+        ],
+      }),
     );
 
-    const result = loadWordgrainDir(tmpDir);
+    const result = parseWordgrainFile(filePath);
 
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('valid');
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('test-rapper');
+    expect(result?.grains).toHaveLength(2);
+    expect(result?.grains[0]?.word).toBe('drip');
+    expect(result?.grains[0]?.tags).toEqual(['style']);
+    expect(result?.grains[1]?.word).toBe('go hard');
+    expect(result?.grains[1]?.context).toBe('motivation');
   });
 
-  it('should skip files without .wg.json extension', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'not-wg.json'),
-      JSON.stringify({ name: 'skip', grains: [{ word: 'skip' }] }),
-    );
-
-    const result = loadWordgrainDir(tmpDir);
-    expect(result).toEqual([]);
+  it('should return null for non-existent file', () => {
+    const result = parseWordgrainFile('/nonexistent/path/file.wg.json');
+    expect(result).toBeNull();
   });
 
-  it('should skip files with missing name field', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'no-name.wg.json'),
-      JSON.stringify({ grains: [{ word: 'test' }] }),
-    );
-
-    const result = loadWordgrainDir(tmpDir);
-    expect(result).toEqual([]);
+  it('should return null for malformed JSON', () => {
+    const filePath = path.join(tmpDir, 'bad.wg.json');
+    fs.writeFileSync(filePath, '{ invalid json }');
+    const result = parseWordgrainFile(filePath);
+    expect(result).toBeNull();
   });
 
-  it('should skip files with missing grains array', () => {
-    fs.writeFileSync(path.join(tmpDir, 'no-grains.wg.json'), JSON.stringify({ name: 'test' }));
+  it('should return null for missing name field', () => {
+    const filePath = path.join(tmpDir, 'no-name.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ grains: [{ word: 'test' }] }));
+    const result = parseWordgrainFile(filePath);
+    expect(result).toBeNull();
+  });
 
-    const result = loadWordgrainDir(tmpDir);
-    expect(result).toEqual([]);
+  it('should return null for missing grains array', () => {
+    const filePath = path.join(tmpDir, 'no-grains.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ name: 'test' }));
+    const result = parseWordgrainFile(filePath);
+    expect(result).toBeNull();
   });
 
   it('should skip invalid grains within a valid file', () => {
+    const filePath = path.join(tmpDir, 'mixed.wg.json');
     fs.writeFileSync(
-      path.join(tmpDir, 'mixed.wg.json'),
+      filePath,
       JSON.stringify({
         name: 'mixed',
         grains: [{ word: 'valid' }, { notAWord: 'invalid' }, 42, null, { word: 'also-valid' }],
       }),
     );
 
-    const result = loadWordgrainDir(tmpDir);
+    const result = parseWordgrainFile(filePath);
 
-    expect(result).toHaveLength(1);
-    expect(result[0]?.grains).toHaveLength(2);
-    expect(result[0]?.grains[0]?.word).toBe('valid');
-    expect(result[0]?.grains[1]?.word).toBe('also-valid');
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(2);
+    expect(result?.grains[0]?.word).toBe('valid');
+    expect(result?.grains[1]?.word).toBe('also-valid');
   });
 
-  it('should load multiple .wg.json files', () => {
+  it('should load barscan format files with meta.artist', () => {
+    const filePath = path.join(tmpDir, 'barscan.wg.json');
     fs.writeFileSync(
-      path.join(tmpDir, 'a.wg.json'),
-      JSON.stringify({ name: 'rapper-a', grains: [{ word: 'flex' }] }),
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, 'b.wg.json'),
-      JSON.stringify({ name: 'rapper-b', grains: [{ word: 'bars' }] }),
+      filePath,
+      JSON.stringify({
+        meta: { artist: 'barscan-artist' },
+        grains: [{ word: 'flow', tags: ['style'] }],
+      }),
     );
 
-    const result = loadWordgrainDir(tmpDir);
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('barscan-artist');
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('flow');
+  });
+
+  it('should return null for files with neither name nor meta.artist', () => {
+    const filePath = path.join(tmpDir, 'no-name-no-meta.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ grains: [{ word: 'test' }] }));
+    const result = parseWordgrainFile(filePath);
+    expect(result).toBeNull();
+  });
+
+  it('should prefer top-level name over meta.artist', () => {
+    const filePath = path.join(tmpDir, 'both.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'top-level-name',
+        meta: { artist: 'meta-artist' },
+        grains: [{ word: 'bars' }],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('top-level-name');
+  });
+});
+
+describe('loadWordgrainFiles', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-load-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should load valid .wg.json files from paths', () => {
+    const fileA = path.join(tmpDir, 'a.wg.json');
+    const fileB = path.join(tmpDir, 'b.wg.json');
+    fs.writeFileSync(fileA, JSON.stringify({ name: 'rapper-a', grains: [{ word: 'flex' }] }));
+    fs.writeFileSync(fileB, JSON.stringify({ name: 'rapper-b', grains: [{ word: 'bars' }] }));
+
+    const result = loadWordgrainFiles([fileA, fileB]);
 
     expect(result).toHaveLength(2);
     const names = result.map((f) => f.name).sort();
     expect(names).toEqual(['rapper-a', 'rapper-b']);
   });
 
-  it('should return empty array when path is a file not a directory', () => {
-    const filePath = path.join(tmpDir, 'not-a-dir');
-    fs.writeFileSync(filePath, 'hello');
-
-    const result = loadWordgrainDir(filePath);
+  it('should return empty array for empty paths list', () => {
+    const result = loadWordgrainFiles([]);
     expect(result).toEqual([]);
   });
 
-  it('should load barscan format files with meta.artist', () => {
-    const fileContent = JSON.stringify({
-      meta: { artist: 'barscan-artist' },
-      grains: [{ word: 'flow', tags: ['style'] }],
-    });
-    fs.writeFileSync(path.join(tmpDir, 'barscan.wg.json'), fileContent);
+  it('should skip non-existent files', () => {
+    const validFile = path.join(tmpDir, 'valid.wg.json');
+    fs.writeFileSync(validFile, JSON.stringify({ name: 'valid', grains: [{ word: 'fire' }] }));
 
-    const result = loadWordgrainDir(tmpDir);
+    const result = loadWordgrainFiles(['/nonexistent/path.wg.json', validFile]);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('barscan-artist');
-    expect(result[0]?.grains).toHaveLength(1);
-    expect(result[0]?.grains[0]?.word).toBe('flow');
+    expect(result[0]?.name).toBe('valid');
   });
 
-  it('should skip files with neither name nor meta.artist', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'no-name-no-meta.wg.json'),
-      JSON.stringify({ grains: [{ word: 'test' }] }),
-    );
+  it('should skip malformed files', () => {
+    const badFile = path.join(tmpDir, 'bad.wg.json');
+    const goodFile = path.join(tmpDir, 'good.wg.json');
+    fs.writeFileSync(badFile, '{ invalid json }');
+    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'fire' }] }));
 
-    const result = loadWordgrainDir(tmpDir);
-    expect(result).toEqual([]);
-  });
-
-  it('should prefer top-level name over meta.artist', () => {
-    const fileContent = JSON.stringify({
-      name: 'top-level-name',
-      meta: { artist: 'meta-artist' },
-      grains: [{ word: 'bars' }],
-    });
-    fs.writeFileSync(path.join(tmpDir, 'both.wg.json'), fileContent);
-
-    const result = loadWordgrainDir(tmpDir);
+    const result = loadWordgrainFiles([badFile, goodFile]);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('top-level-name');
+    expect(result[0]?.name).toBe('valid');
   });
 });

--- a/src/services/wordgrain/wordgrain-loader.ts
+++ b/src/services/wordgrain/wordgrain-loader.ts
@@ -1,8 +1,7 @@
 /**
- * Load .wg.json files from a directory
+ * Load .wg.json files from individual file paths
  */
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import type { Grain, WordgrainFile } from './types.js';
 
 /**
@@ -55,29 +54,23 @@ export function parseWordgrainFile(filePath: string): WordgrainFile | null {
 }
 
 /**
- * Load all .wg.json files from a directory
- * @param dirPath - Path to directory containing .wg.json files
+ * Load wordgrain files from individual file paths
+ * @param filePaths - Array of paths to .wg.json files
  * @returns Array of parsed WordgrainFile objects
  */
-export function loadWordgrainDir(dirPath: string): WordgrainFile[] {
-  try {
-    if (!fs.existsSync(dirPath)) return [];
-    if (!fs.statSync(dirPath).isDirectory()) return [];
+export function loadWordgrainFiles(filePaths: string[]): WordgrainFile[] {
+  const results: WordgrainFile[] = [];
 
-    const entries = fs.readdirSync(dirPath);
-    const results: WordgrainFile[] = [];
-
-    for (const entry of entries) {
-      if (!entry.endsWith('.wg.json')) continue;
-      const filePath = path.join(dirPath, entry);
+  for (const filePath of filePaths) {
+    try {
       const parsed = parseWordgrainFile(filePath);
       if (parsed) {
         results.push(parsed);
       }
+    } catch {
+      // Skip files that can't be read
     }
-
-    return results;
-  } catch {
-    return [];
   }
+
+  return results;
 }

--- a/src/services/wordgrain/wordgrain-manager.test.ts
+++ b/src/services/wordgrain/wordgrain-manager.test.ts
@@ -3,10 +3,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  addWordgrainFile,
   getWordgrainStats,
   listWordgrainFiles,
-  removeWordgrainFile,
+  registerWordgrainFile,
 } from './wordgrain-manager.js';
 
 describe('listWordgrainFiles', () => {
@@ -20,24 +19,21 @@ describe('listWordgrainFiles', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should return empty array for missing directory', () => {
-    expect(listWordgrainFiles('/nonexistent/path')).toEqual([]);
-  });
-
-  it('should return empty array for empty directory', () => {
-    expect(listWordgrainFiles(tmpDir)).toEqual([]);
+  it('should return empty array for empty paths list', () => {
+    expect(listWordgrainFiles([])).toEqual([]);
   });
 
   it('should list valid .wg.json files with metadata', () => {
+    const filePath = path.join(tmpDir, 'test.wg.json');
     fs.writeFileSync(
-      path.join(tmpDir, 'test.wg.json'),
+      filePath,
       JSON.stringify({
         name: 'test-vocab',
         grains: [{ word: 'hello' }, { word: 'world' }],
       }),
     );
 
-    const result = listWordgrainFiles(tmpDir);
+    const result = listWordgrainFiles([filePath]);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
@@ -48,152 +44,118 @@ describe('listWordgrainFiles', () => {
   });
 
   it('should sort files alphabetically by filename', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'b.wg.json'),
-      JSON.stringify({ name: 'beta', grains: [{ word: 'b' }] }),
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, 'a.wg.json'),
-      JSON.stringify({ name: 'alpha', grains: [{ word: 'a' }] }),
-    );
+    const fileB = path.join(tmpDir, 'b.wg.json');
+    const fileA = path.join(tmpDir, 'a.wg.json');
+    fs.writeFileSync(fileB, JSON.stringify({ name: 'beta', grains: [{ word: 'b' }] }));
+    fs.writeFileSync(fileA, JSON.stringify({ name: 'alpha', grains: [{ word: 'a' }] }));
 
-    const result = listWordgrainFiles(tmpDir);
+    const result = listWordgrainFiles([fileB, fileA]);
 
     expect(result).toHaveLength(2);
     expect(result[0]?.filename).toBe('a.wg.json');
     expect(result[1]?.filename).toBe('b.wg.json');
   });
 
-  it('should skip malformed files', () => {
-    fs.writeFileSync(path.join(tmpDir, 'bad.wg.json'), '{ invalid }');
-    fs.writeFileSync(
-      path.join(tmpDir, 'good.wg.json'),
-      JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }),
-    );
+  it('should skip non-existent files', () => {
+    const goodFile = path.join(tmpDir, 'good.wg.json');
+    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
 
-    const result = listWordgrainFiles(tmpDir);
+    const result = listWordgrainFiles(['/nonexistent/bad.wg.json', goodFile]);
 
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('valid');
   });
 
-  it('should return empty array when path is a file', () => {
-    const filePath = path.join(tmpDir, 'not-a-dir');
-    fs.writeFileSync(filePath, 'hello');
-    expect(listWordgrainFiles(filePath)).toEqual([]);
+  it('should skip malformed files', () => {
+    const badFile = path.join(tmpDir, 'bad.wg.json');
+    const goodFile = path.join(tmpDir, 'good.wg.json');
+    fs.writeFileSync(badFile, '{ invalid }');
+    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
+
+    const result = listWordgrainFiles([badFile, goodFile]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('valid');
   });
 });
 
-describe('addWordgrainFile', () => {
+describe('registerWordgrainFile', () => {
   let tmpDir: string;
-  let targetDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-mgr-add-'));
-    targetDir = path.join(tmpDir, 'target');
-    fs.mkdirSync(targetDir);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-mgr-reg-'));
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should copy a valid .wg.json file to target directory', () => {
-    const sourcePath = path.join(tmpDir, 'source.wg.json');
-    fs.writeFileSync(sourcePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
+  it('should accept a valid .wg.json file', () => {
+    const filePath = path.join(tmpDir, 'source.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
 
-    const result = addWordgrainFile(sourcePath, targetDir);
-
-    expect(result).toEqual({ success: true });
-    expect(fs.existsSync(path.join(targetDir, 'source.wg.json'))).toBe(true);
-  });
-
-  it('should create target directory if it does not exist', () => {
-    const newTarget = path.join(tmpDir, 'new-dir');
-    const sourcePath = path.join(tmpDir, 'source.wg.json');
-    fs.writeFileSync(sourcePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
-
-    const result = addWordgrainFile(sourcePath, newTarget);
+    const result = registerWordgrainFile(filePath, []);
 
     expect(result).toEqual({ success: true });
-    expect(fs.existsSync(path.join(newTarget, 'source.wg.json'))).toBe(true);
   });
 
-  it('should reject non-existent source file', () => {
-    const result = addWordgrainFile('/nonexistent/file.wg.json', targetDir);
+  it('should reject non-existent file', () => {
+    const result = registerWordgrainFile('/nonexistent/file.wg.json', []);
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('Source file does not exist');
+    expect(result.error).toBe('File does not exist');
   });
 
-  it('should reject source that is a directory', () => {
-    const dirSource = path.join(tmpDir, 'subdir.wg.json');
-    fs.mkdirSync(dirSource);
+  it('should reject path that is a directory', () => {
+    const dirPath = path.join(tmpDir, 'subdir.wg.json');
+    fs.mkdirSync(dirPath);
 
-    const result = addWordgrainFile(dirSource, targetDir);
+    const result = registerWordgrainFile(dirPath, []);
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('Source path is not a file');
+    expect(result.error).toBe('Path is not a file');
   });
 
   it('should reject files without .wg.json extension', () => {
-    const sourcePath = path.join(tmpDir, 'source.json');
-    fs.writeFileSync(sourcePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
+    const filePath = path.join(tmpDir, 'source.json');
+    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
 
-    const result = addWordgrainFile(sourcePath, targetDir);
+    const result = registerWordgrainFile(filePath, []);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('File must have .wg.json extension');
   });
 
   it('should reject invalid wordgrain file format', () => {
-    const sourcePath = path.join(tmpDir, 'bad.wg.json');
-    fs.writeFileSync(sourcePath, '{ "not": "valid" }');
+    const filePath = path.join(tmpDir, 'bad.wg.json');
+    fs.writeFileSync(filePath, '{ "not": "valid" }');
 
-    const result = addWordgrainFile(sourcePath, targetDir);
+    const result = registerWordgrainFile(filePath, []);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Invalid wordgrain file format');
   });
 
-  it('should reject when file already exists in target', () => {
-    const sourcePath = path.join(tmpDir, 'dup.wg.json');
-    fs.writeFileSync(sourcePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
-    fs.writeFileSync(path.join(targetDir, 'dup.wg.json'), '{}');
+  it('should reject already registered file', () => {
+    const filePath = path.join(tmpDir, 'dup.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
 
-    const result = addWordgrainFile(sourcePath, targetDir);
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('already exists');
-  });
-});
-
-describe('removeWordgrainFile', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-mgr-rm-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  it('should remove an existing file', () => {
-    const filePath = path.join(tmpDir, 'test.wg.json');
-    fs.writeFileSync(filePath, '{}');
-
-    const result = removeWordgrainFile('test.wg.json', tmpDir);
-
-    expect(result).toEqual({ success: true });
-    expect(fs.existsSync(filePath)).toBe(false);
-  });
-
-  it('should return error for non-existent file', () => {
-    const result = removeWordgrainFile('missing.wg.json', tmpDir);
+    const result = registerWordgrainFile(filePath, [filePath]);
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('not found');
+    expect(result.error).toBe('File is already registered');
+  });
+
+  it('should detect duplicate registration by resolved path', () => {
+    const filePath = path.join(tmpDir, 'dup.wg.json');
+    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
+    // Use a relative-looking path that resolves to the same file
+    const existingPath = path.resolve(filePath);
+
+    const result = registerWordgrainFile(filePath, [existingPath]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('File is already registered');
   });
 });
 
@@ -208,8 +170,8 @@ describe('getWordgrainStats', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should return empty stats for missing directory', () => {
-    const stats = getWordgrainStats('/nonexistent/path');
+  it('should return empty stats for empty paths list', () => {
+    const stats = getWordgrainStats([]);
 
     expect(stats).toEqual({
       totalFiles: 0,
@@ -220,8 +182,8 @@ describe('getWordgrainStats', () => {
     });
   });
 
-  it('should return empty stats for empty directory', () => {
-    const stats = getWordgrainStats(tmpDir);
+  it('should return empty stats for non-existent files', () => {
+    const stats = getWordgrainStats(['/nonexistent/path.wg.json']);
 
     expect(stats).toEqual({
       totalFiles: 0,
@@ -233,8 +195,10 @@ describe('getWordgrainStats', () => {
   });
 
   it('should compute aggregate stats across files', () => {
+    const fileA = path.join(tmpDir, 'a.wg.json');
+    const fileB = path.join(tmpDir, 'b.wg.json');
     fs.writeFileSync(
-      path.join(tmpDir, 'a.wg.json'),
+      fileA,
       JSON.stringify({
         name: 'vocab-a',
         grains: [
@@ -244,7 +208,7 @@ describe('getWordgrainStats', () => {
       }),
     );
     fs.writeFileSync(
-      path.join(tmpDir, 'b.wg.json'),
+      fileB,
       JSON.stringify({
         name: 'vocab-b',
         grains: [
@@ -254,7 +218,7 @@ describe('getWordgrainStats', () => {
       }),
     );
 
-    const stats = getWordgrainStats(tmpDir);
+    const stats = getWordgrainStats([fileA, fileB]);
 
     expect(stats.totalFiles).toBe(2);
     expect(stats.totalGrains).toBe(4);
@@ -264,25 +228,22 @@ describe('getWordgrainStats', () => {
   });
 
   it('should skip malformed files', () => {
-    fs.writeFileSync(path.join(tmpDir, 'bad.wg.json'), '{ invalid }');
-    fs.writeFileSync(
-      path.join(tmpDir, 'good.wg.json'),
-      JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }),
-    );
+    const badFile = path.join(tmpDir, 'bad.wg.json');
+    const goodFile = path.join(tmpDir, 'good.wg.json');
+    fs.writeFileSync(badFile, '{ invalid }');
+    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
 
-    const stats = getWordgrainStats(tmpDir);
+    const stats = getWordgrainStats([badFile, goodFile]);
 
     expect(stats.totalFiles).toBe(1);
     expect(stats.totalGrains).toBe(1);
   });
 
   it('should handle empty grains in stats', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'empty.wg.json'),
-      JSON.stringify({ name: 'empty', grains: [] }),
-    );
+    const emptyFile = path.join(tmpDir, 'empty.wg.json');
+    fs.writeFileSync(emptyFile, JSON.stringify({ name: 'empty', grains: [] }));
 
-    const stats = getWordgrainStats(tmpDir);
+    const stats = getWordgrainStats([emptyFile]);
 
     expect(stats.totalFiles).toBe(1);
     expect(stats.totalGrains).toBe(0);

--- a/src/services/wordgrain/wordgrain-manager.ts
+++ b/src/services/wordgrain/wordgrain-manager.ts
@@ -1,5 +1,8 @@
 /**
  * Wordgrain file management operations
+ *
+ * Manages individual file paths instead of a directory.
+ * Files are referenced in-place and not copied.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -20,74 +23,62 @@ export interface WordgrainStats {
 }
 
 /**
- * List all .wg.json files in the directory with metadata
+ * List registered wordgrain files with metadata
  */
-export function listWordgrainFiles(dirPath: string): WordgrainFileInfo[] {
-  try {
-    if (!fs.existsSync(dirPath)) return [];
-    if (!fs.statSync(dirPath).isDirectory()) return [];
+export function listWordgrainFiles(filePaths: string[]): WordgrainFileInfo[] {
+  const results: WordgrainFileInfo[] = [];
 
-    const entries = fs.readdirSync(dirPath);
-    const results: WordgrainFileInfo[] = [];
-
-    for (const entry of entries) {
-      if (!entry.endsWith('.wg.json')) continue;
-      const filePath = path.join(dirPath, entry);
+  for (const filePath of filePaths) {
+    try {
       const parsed = parseWordgrainFile(filePath);
       if (parsed) {
         results.push({
-          filename: entry,
+          filename: path.basename(filePath),
           name: parsed.name,
           grainCount: parsed.grains.length,
         });
       }
+    } catch {
+      // Skip files that can't be read
     }
-
-    return results.sort((a, b) => a.filename.localeCompare(b.filename));
-  } catch {
-    return [];
   }
+
+  return results.sort((a, b) => a.filename.localeCompare(b.filename));
 }
 
 /**
- * Add a .wg.json file to the wordgrain directory by copying from source path
+ * Validate a file path for registration as a wordgrain file.
+ * Does not copy the file; only checks existence and format.
  */
-export function addWordgrainFile(
-  sourcePath: string,
-  dirPath: string,
+export function registerWordgrainFile(
+  filePath: string,
+  existingPaths: string[],
 ): { success: boolean; error?: string } {
   try {
-    if (!fs.existsSync(sourcePath)) {
-      return { success: false, error: 'Source file does not exist' };
+    if (!fs.existsSync(filePath)) {
+      return { success: false, error: 'File does not exist' };
     }
 
-    if (!fs.statSync(sourcePath).isFile()) {
-      return { success: false, error: 'Source path is not a file' };
+    if (!fs.statSync(filePath).isFile()) {
+      return { success: false, error: 'Path is not a file' };
     }
 
-    if (!sourcePath.endsWith('.wg.json')) {
+    if (!filePath.endsWith('.wg.json')) {
       return { success: false, error: 'File must have .wg.json extension' };
     }
 
     // Validate the file is a valid wordgrain file
-    const parsed = parseWordgrainFile(sourcePath);
+    const parsed = parseWordgrainFile(filePath);
     if (!parsed) {
       return { success: false, error: 'Invalid wordgrain file format' };
     }
 
-    // Ensure target directory exists
-    if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true });
+    // Check for duplicate registration
+    const resolved = path.resolve(filePath);
+    if (existingPaths.some((p) => path.resolve(p) === resolved)) {
+      return { success: false, error: 'File is already registered' };
     }
 
-    const filename = path.basename(sourcePath);
-    const targetPath = path.join(dirPath, filename);
-
-    if (fs.existsSync(targetPath)) {
-      return { success: false, error: `File "${filename}" already exists in wordgrain directory` };
-    }
-
-    fs.copyFileSync(sourcePath, targetPath);
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
@@ -96,31 +87,9 @@ export function addWordgrainFile(
 }
 
 /**
- * Remove a .wg.json file from the wordgrain directory
+ * Compute aggregate statistics for registered wordgrain files
  */
-export function removeWordgrainFile(
-  filename: string,
-  dirPath: string,
-): { success: boolean; error?: string } {
-  try {
-    const filePath = path.join(dirPath, filename);
-
-    if (!fs.existsSync(filePath)) {
-      return { success: false, error: `File "${filename}" not found` };
-    }
-
-    fs.unlinkSync(filePath);
-    return { success: true };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return { success: false, error: message };
-  }
-}
-
-/**
- * Compute aggregate statistics for all wordgrain files in the directory
- */
-export function getWordgrainStats(dirPath: string): WordgrainStats {
+export function getWordgrainStats(filePaths: string[]): WordgrainStats {
   const empty: WordgrainStats = {
     totalFiles: 0,
     totalGrains: 0,
@@ -130,19 +99,13 @@ export function getWordgrainStats(dirPath: string): WordgrainStats {
   };
 
   try {
-    if (!fs.existsSync(dirPath)) return empty;
-    if (!fs.statSync(dirPath).isDirectory()) return empty;
-
-    const entries = fs.readdirSync(dirPath);
     let totalFiles = 0;
     let totalGrains = 0;
     const wordSet = new Set<string>();
     const phraseSet = new Set<string>();
     const tagSet = new Set<string>();
 
-    for (const entry of entries) {
-      if (!entry.endsWith('.wg.json')) continue;
-      const filePath = path.join(dirPath, entry);
+    for (const filePath of filePaths) {
       const parsed = parseWordgrainFile(filePath);
       if (!parsed) continue;
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,7 +8,6 @@ import { ConfigView } from './components/config/ConfigView.js';
 import { EntryList } from './components/entries/EntryList.js';
 import { SplashScreen } from './components/splash/SplashScreen.js';
 import { WriteView } from './components/write/WriteView.js';
-import { useConfig } from './context/ConfigContext.js';
 import { NavigationProvider, useNavigation } from './context/NavigationContext.js';
 import { useQueue } from './context/QueueContext.js';
 
@@ -16,7 +15,6 @@ function AppContent() {
   const { exit } = useApp();
   const { mode, toggleMode, switchToConfig } = useNavigation();
   const { status: queueStatus } = useQueue();
-  const { config } = useConfig();
   const [isViewingDetail, setIsViewingDetail] = useState(false);
   const agentStatus = useAgentStatus();
   useTerminalTitle(agentStatus);
@@ -53,12 +51,7 @@ function AppContent() {
         {mode === 'config' && <ConfigView />}
       </Box>
 
-      <HelpFooter
-        mode={mode}
-        isViewingDetail={isViewingDetail}
-        queueStatus={queueStatus}
-        hasWordgrainDir={!!config.wordgrainDir}
-      />
+      <HelpFooter mode={mode} isViewingDetail={isViewingDetail} queueStatus={queueStatus} />
     </Box>
   );
 }

--- a/src/ui/components/common/HelpFooter.test.tsx
+++ b/src/ui/components/common/HelpFooter.test.tsx
@@ -32,23 +32,12 @@ describe('HelpFooter', () => {
     expect(lastFrame()).toContain('Tab: write');
   });
 
-  it('should show config mode shortcuts with wordgrain dir', () => {
-    const { lastFrame } = render(<HelpFooter mode="config" hasWordgrainDir={true} />);
+  it('should show config mode shortcuts with wordgrain actions', () => {
+    const { lastFrame } = render(<HelpFooter mode="config" />);
 
     expect(lastFrame()).toContain('j/k: navigate');
     expect(lastFrame()).toContain('a: add');
-    expect(lastFrame()).toContain('d: delete');
-    expect(lastFrame()).toContain('r: reload');
-    expect(lastFrame()).toContain('Esc: back');
-    expect(lastFrame()).toContain('q: quit');
-  });
-
-  it('should hide wordgrain shortcuts in config mode without wordgrain dir', () => {
-    const { lastFrame } = render(<HelpFooter mode="config" />);
-
-    expect(lastFrame()).not.toContain('j/k: navigate');
-    expect(lastFrame()).not.toContain('a: add');
-    expect(lastFrame()).not.toContain('d: delete');
+    expect(lastFrame()).toContain('d: unregister');
     expect(lastFrame()).toContain('r: reload');
     expect(lastFrame()).toContain('Esc: back');
     expect(lastFrame()).toContain('q: quit');

--- a/src/ui/components/common/HelpFooter.tsx
+++ b/src/ui/components/common/HelpFooter.tsx
@@ -8,24 +8,15 @@ interface HelpFooterProps {
   mode: AppMode;
   isViewingDetail?: boolean;
   queueStatus?: QueueStatus;
-  hasWordgrainDir?: boolean;
 }
 
-export function HelpFooter({
-  mode,
-  isViewingDetail = false,
-  queueStatus,
-  hasWordgrainDir = false,
-}: HelpFooterProps) {
+export function HelpFooter({ mode, isViewingDetail = false, queueStatus }: HelpFooterProps) {
   const getShortcuts = () => {
     if (mode === 'write') {
       return 'Tab: list | Esc: cancel | q: quit';
     }
     if (mode === 'config') {
-      if (hasWordgrainDir) {
-        return 'j/k: navigate | a: add | d: delete | r: reload | Esc: back | q: quit';
-      }
-      return 'r: reload | Esc: back | q: quit';
+      return 'j/k: navigate | a: add | d: unregister | r: reload | Esc: back | q: quit';
     }
     if (isViewingDetail) {
       return 'Esc/q: back | Tab: write';

--- a/src/ui/components/config/ConfigView.tsx
+++ b/src/ui/components/config/ConfigView.tsx
@@ -9,15 +9,8 @@ import { WordgrainSection } from './WordgrainSection.js';
 
 export function ConfigView() {
   const { switchToList } = useNavigation();
-  const {
-    config,
-    files,
-    selectedFileIndex,
-    setSelectedFileIndex,
-    subMode,
-    setSubMode,
-    reloadFiles,
-  } = useConfig();
+  const { files, selectedFileIndex, setSelectedFileIndex, subMode, setSubMode, reloadFiles } =
+    useConfig();
 
   useInput(
     (input, key) => {
@@ -40,12 +33,12 @@ export function ConfigView() {
         return;
       }
 
-      if (input === 'a' && config.wordgrainDir) {
+      if (input === 'a') {
         setSubMode('add-file');
         return;
       }
 
-      if (input === 'd' && config.wordgrainDir && files.length > 0) {
+      if (input === 'd' && files.length > 0) {
         setSubMode('delete-confirm');
         return;
       }

--- a/src/ui/components/config/DeleteConfirm.tsx
+++ b/src/ui/components/config/DeleteConfirm.tsx
@@ -27,12 +27,12 @@ export function DeleteConfirm() {
     <Box flexDirection="column">
       <Box marginBottom={1}>
         <Text bold color="red">
-          Delete Wordgrain File
+          Unregister Wordgrain File
         </Text>
       </Box>
 
       <Text>
-        Remove <Text bold>{file.filename}</Text> ({file.name}, {file.grainCount} grains)?
+        Unregister <Text bold>{file.filename}</Text> ({file.name}, {file.grainCount} grains)?
       </Text>
 
       <Box marginTop={1}>

--- a/src/ui/components/config/WordgrainSection.tsx
+++ b/src/ui/components/config/WordgrainSection.tsx
@@ -3,22 +3,7 @@ import React from 'react';
 import { useConfig } from '../../context/ConfigContext.js';
 
 export function WordgrainSection() {
-  const { config, files, stats, selectedFileIndex } = useConfig();
-
-  if (!config.wordgrainDir) {
-    return (
-      <Box flexDirection="column">
-        <Box marginBottom={1}>
-          <Text bold color="yellow">
-            Wordgrain Files
-          </Text>
-        </Box>
-        <Box paddingLeft={2}>
-          <Text dimColor>Set MUMBL_WORDGRAIN_DIR to enable wordgrain vocabulary.</Text>
-        </Box>
-      </Box>
-    );
-  }
+  const { files, stats, selectedFileIndex } = useConfig();
 
   return (
     <Box flexDirection="column">
@@ -26,12 +11,11 @@ export function WordgrainSection() {
         <Text bold color="yellow">
           Wordgrain Files
         </Text>
-        <Text dimColor> ({config.wordgrainDir})</Text>
       </Box>
 
       {files.length === 0 ? (
         <Box paddingLeft={2}>
-          <Text dimColor>No wordgrain files found.</Text>
+          <Text dimColor>No wordgrain files registered. Press &apos;a&apos; to add.</Text>
         </Box>
       ) : (
         <Box flexDirection="column" paddingLeft={2}>

--- a/src/ui/context/ConfigContext.tsx
+++ b/src/ui/context/ConfigContext.tsx
@@ -1,13 +1,14 @@
+import * as path from 'node:path';
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { saveConfigFile } from '../../config/config-file.js';
 import type { ResolvedConfig } from '../../config/types.js';
 import {
   type WordgrainFileInfo,
   type WordgrainStats,
-  addWordgrainFile,
   getWordgrainStats,
   listWordgrainFiles,
   loadVocabulary,
-  removeWordgrainFile,
+  registerWordgrainFile,
 } from '../../services/wordgrain/index.js';
 import type { VocabularySet } from '../../services/wordgrain/types.js';
 import { useServices } from './ServiceContext.js';
@@ -56,6 +57,7 @@ const emptyVocabulary: VocabularySet = { words: [], phrases: [], tags: [], sourc
 
 export function ConfigProvider({ config, children }: ConfigProviderProps) {
   const { llmService, reactionService } = useServices();
+  const [wordgrainFiles, setWordgrainFiles] = useState<string[]>(config.wordgrainFiles ?? []);
   const [files, setFiles] = useState<WordgrainFileInfo[]>([]);
   const [stats, setStats] = useState<WordgrainStats>(emptyStats);
   const [selectedFileIndex, setSelectedFileIndex] = useState(0);
@@ -63,25 +65,30 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
   const [error, setError] = useState<string | null>(null);
 
   const refreshFiles = useCallback(() => {
-    if (!config.wordgrainDir) {
+    if (wordgrainFiles.length === 0) {
       setFiles([]);
       setStats(emptyStats);
       return;
     }
-    setFiles(listWordgrainFiles(config.wordgrainDir));
-    setStats(getWordgrainStats(config.wordgrainDir));
-  }, [config.wordgrainDir]);
+    setFiles(listWordgrainFiles(wordgrainFiles));
+    setStats(getWordgrainStats(wordgrainFiles));
+  }, [wordgrainFiles]);
 
   const hotReload = useCallback(() => {
-    if (!config.wordgrainDir) return;
-    const vocabulary = loadVocabulary(config.wordgrainDir);
+    if (wordgrainFiles.length === 0) {
+      llmService.setVocabulary(emptyVocabulary);
+      reactionService.setVocabulary(emptyVocabulary);
+      return;
+    }
+    const vocabulary = loadVocabulary(wordgrainFiles);
     llmService.setVocabulary(vocabulary ?? emptyVocabulary);
     reactionService.setVocabulary(vocabulary ?? emptyVocabulary);
-  }, [config.wordgrainDir, llmService, reactionService]);
+  }, [wordgrainFiles, llmService, reactionService]);
 
   useEffect(() => {
     refreshFiles();
-  }, [refreshFiles]);
+    hotReload();
+  }, [refreshFiles, hotReload]);
 
   const clearError = useCallback(() => {
     setError(null);
@@ -89,41 +96,31 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
 
   const addFile = useCallback(
     (sourcePath: string) => {
-      if (!config.wordgrainDir) {
-        setError('Wordgrain directory is not configured');
-        return;
-      }
-      const result = addWordgrainFile(sourcePath, config.wordgrainDir);
+      const resolved = path.resolve(sourcePath);
+      const result = registerWordgrainFile(resolved, wordgrainFiles);
       if (!result.success) {
         setError(result.error ?? 'Failed to add file');
         return;
       }
+      const updated = [...wordgrainFiles, resolved];
+      setWordgrainFiles(updated);
+      saveConfigFile({ wordgrainFiles: updated });
       setError(null);
-      refreshFiles();
-      hotReload();
       setSubMode('normal');
     },
-    [config.wordgrainDir, refreshFiles, hotReload],
+    [wordgrainFiles],
   );
 
   const removeFile = useCallback(
     (filename: string) => {
-      if (!config.wordgrainDir) {
-        setError('Wordgrain directory is not configured');
-        return;
-      }
-      const result = removeWordgrainFile(filename, config.wordgrainDir);
-      if (!result.success) {
-        setError(result.error ?? 'Failed to remove file');
-        return;
-      }
+      const updated = wordgrainFiles.filter((fp) => path.basename(fp) !== filename);
+      setWordgrainFiles(updated);
+      saveConfigFile({ wordgrainFiles: updated });
       setError(null);
       setSelectedFileIndex((prev) => Math.max(0, prev - 1));
-      refreshFiles();
-      hotReload();
       setSubMode('normal');
     },
-    [config.wordgrainDir, refreshFiles, hotReload],
+    [wordgrainFiles],
   );
 
   const reloadFiles = useCallback(() => {


### PR DESCRIPTION
## Summary

Replace directory-based wordgrain management with individual file path registration. Files are now referenced in-place via `~/.config/mumbl/config.json` instead of being copied to a wordgrain directory.

- Replace `wordgrainDir` (string) with `wordgrainFiles` (string[]) across all config types
- Add `saveConfigFile()` for persisting wordgrain file paths to config.json
- Remove `MUMBL_WORDGRAIN_DIR` environment variable support
- Replace copy-based `addWordgrainFile` with validation-only `registerWordgrainFile`
- Always show wordgrain shortcuts in config mode (no directory check needed)

## Changes

- **src/config/types.ts**: `wordgrainDir?: string` -> `wordgrainFiles?: string[]`
- **src/config/config-file.ts**: Load `wordgrainFiles` array, add `saveConfigFile()`
- **src/config/env-vars.ts**: Remove `MUMBL_WORDGRAIN_DIR` support
- **src/config/resolve-config.ts**: Use `wordgrainFiles` from config file only
- **src/services/wordgrain/wordgrain-manager.ts**: File-path-based `listWordgrainFiles`, `registerWordgrainFile`, `getWordgrainStats`
- **src/services/wordgrain/wordgrain-loader.ts**: Replace `loadWordgrainDir` with `loadWordgrainFiles`
- **src/services/wordgrain/index.ts**: Update exports and `loadVocabulary` signature
- **src/ui/context/ConfigContext.tsx**: Manage file paths with config.json persistence
- **src/ui/components/config/ConfigView.tsx**: Remove `wordgrainDir` gate on shortcuts
- **src/ui/components/config/WordgrainSection.tsx**: Always show file list
- **src/ui/components/config/DeleteConfirm.tsx**: "Delete" -> "Unregister" wording
- **src/ui/components/common/HelpFooter.tsx**: Always show wordgrain shortcuts
- **src/ui/App.tsx**: Remove `hasWordgrainDir` prop
- **src/index.tsx**: Use `config.wordgrainFiles` for vocabulary loading

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm vitest run` passes (715 tests)
- [ ] `pnpm dev` -> Config screen -> press `a` -> enter file path -> file loads
- [ ] `~/.config/mumbl/config.json` contains `wordgrainFiles` array after adding
- [ ] Restart app -> registered files still loaded
- [ ] Press `d` -> file unregistered (not deleted from disk)