### PR TITLE
Add mood-mapping rules to reaction prompt

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -262,12 +262,32 @@ describe('createReactionPrompt', () => {
     expect(systemContent).toContain('"work is tough"');
   });
 
-  it('should include variation instruction', () => {
+  it('should include variation instruction and mood mapping', () => {
     const messages = createReactionPrompt('test');
     const systemContent = messages[0]?.content ?? '';
 
     expect(systemContent).toContain('never repeat the same word for different entries');
-    expect(systemContent).toContain('spread across all categories');
+    expect(systemContent).toContain('Mood mapping');
+    expect(systemContent).toContain('classify the entry');
+  });
+
+  it('should include mood mapping rules for ja language', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Achievement (おつ, ナイス, すげ, えらい)');
+    expect(systemContent).toContain('Negative/tough (つら, だる, きつ, やば)');
+    expect(systemContent).toContain('Surprise (まじか, えぐ, やべ, うそ)');
+    expect(systemContent).toContain('Feeling it (それな, わかる, たしかに)');
+  });
+
+  it('should include mood mapping rules for en language', () => {
+    const messages = createReactionPrompt('test', { language: 'en' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Achievement (W, goated, clutch, lets go)');
+    expect(systemContent).toContain('Negative/tough (damn, oof, rough, bruh)');
+    expect(systemContent).toContain('Surprise (whoa, no way, wild, crazy)');
   });
 
   it('should merge vocabulary words into word options instead of separate section', () => {

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -375,12 +375,35 @@ export function createReactionPrompt(
     ? buildRecentEntriesContext(options.recentEntries, language)
     : '';
 
+  const moodMapping =
+    language === 'ja'
+      ? `## Mood mapping (classify the entry, then pick from that category):
+- Task done / finished -> Achievement (おつ, ナイス, すげ, えらい)
+- Tired / negative / complaining -> Negative/tough (つら, だる, きつ, やば)
+- Happy / good news -> Positive vibes (最高, 神, いいね, よい)
+- Boring / mundane / daily routine -> Chill (ふーん, あっそ, ·)
+- Shocking / unexpected -> Surprise (まじか, えぐ, やべ, うそ)
+- Relatable / empathy -> Feeling it (それな, わかる, たしかに)
+- Tough situation / sympathy -> Sympathy (つらみ, あるある, しゃない)
+- Simple acknowledgment -> Acknowledgment (な, うん, そう, おけ)`
+      : `## Mood mapping (classify the entry, then pick from that category):
+- Task done / finished -> Achievement (W, goated, clutch, lets go)
+- Tired / negative / complaining -> Negative/tough (damn, oof, rough, bruh)
+- Happy / good news -> Positive vibes (lit, fire, dope, nice)
+- Boring / mundane / daily routine -> Chill (meh, whatever, ·)
+- Shocking / unexpected -> Surprise (whoa, no way, wild, crazy)
+- Relatable / empathy -> Feeling it (fr, real, facts, mood)
+- Tough situation / sympathy -> Sympathy (pain, rip, been there)
+- Simple acknowledgment -> Acknowledgment (bet, word, aight, cool)`;
+
   // Pass undefined for vocabulary so no separate vocabulary section is appended
   return createPromptPair(
     `You respond with ONE word only. ${styleLabel}. Curt and distant. Vary your responses - never repeat the same word for different entries.
 
-Word options (spread across all categories, not just one):
+Word options:
 ${wordList}
+
+${moodMapping}
 
 NEVER use:
 - Full sentences


### PR DESCRIPTION
## Summary

Implements issue #131 by adding explicit mood-to-category mapping rules to the reaction prompt.

- Replace vague "spread across all categories" with structured mood mapping
- LLM now classifies entry mood first, then picks word from matching category
- Covers 8 mood categories: Achievement, Negative, Positive, Chill, Surprise, Feeling it, Sympathy, Acknowledgment

Depends on: #133 (issue #130)

## Changes

- **src/services/llm/prompts.ts**: Add mood mapping section to reaction prompt for both JA and EN
- **src/services/llm/prompts.test.ts**: Add tests for mood mapping rules in both languages

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 723 tests pass
- [x] `pnpm ci:all` passes (pre-push hook)