### PR TITLE
Add recent-reaction deduplication

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -290,6 +290,30 @@ describe('createReactionPrompt', () => {
     expect(systemContent).toContain('Surprise (whoa, no way, wild, crazy)');
   });
 
+  it('should include dedup block when recentReactions provided', () => {
+    const messages = createReactionPrompt('test', {
+      recentReactions: ['うん', 'そう', 'な'],
+    });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Do NOT repeat these recent reactions');
+    expect(systemContent).toContain('うん, そう, な');
+  });
+
+  it('should not include dedup block when no recentReactions', () => {
+    const messages = createReactionPrompt('test');
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).not.toContain('Do NOT repeat');
+  });
+
+  it('should not include dedup block when recentReactions is empty', () => {
+    const messages = createReactionPrompt('test', { recentReactions: [] });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).not.toContain('Do NOT repeat');
+  });
+
   it('should merge vocabulary words into word options instead of separate section', () => {
     const messages = createReactionPrompt('test', undefined, testVocabulary);
     const systemContent = messages[0]?.content ?? '';

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -265,6 +265,7 @@ Bad: "It sounds like you're processing a lot. What do you think is driving these
 export interface ReactionPromptOptions {
   language?: DetectedLanguage;
   recentEntries?: string[];
+  recentReactions?: string[];
 }
 
 /**
@@ -396,6 +397,12 @@ export function createReactionPrompt(
 - Tough situation / sympathy -> Sympathy (pain, rip, been there)
 - Simple acknowledgment -> Acknowledgment (bet, word, aight, cool)`;
 
+  const recentReactions = options?.recentReactions ?? [];
+  const dedupBlock =
+    recentReactions.length > 0
+      ? `\nDo NOT repeat these recent reactions: ${recentReactions.join(', ')}\n`
+      : '';
+
   // Pass undefined for vocabulary so no separate vocabulary section is appended
   return createPromptPair(
     `You respond with ONE word only. ${styleLabel}. Curt and distant. Vary your responses - never repeat the same word for different entries.
@@ -404,7 +411,7 @@ Word options:
 ${wordList}
 
 ${moodMapping}
-
+${dedupBlock}
 NEVER use:
 - Full sentences
 - Polite language

--- a/src/services/reaction-service.test.ts
+++ b/src/services/reaction-service.test.ts
@@ -166,6 +166,7 @@ describe('ReactionService', () => {
       expect(mockLLMService.react).toHaveBeenCalledWith('work is killing me', {
         language: 'en',
         recentEntries: [],
+        recentReactions: undefined,
       });
       expect(reaction?.content).toBe("that's rough");
       expect(reaction?.reactionType).toBe('custom');
@@ -294,6 +295,38 @@ describe('ReactionService', () => {
 
       expect(reaction?.content).toBe('vibe');
       expect(reaction?.reactionType).toBe('read');
+    });
+
+    it('should pass recent reactions to LLM after generating reactions', async () => {
+      const mockLLMService = {
+        react: vi.fn().mockResolvedValue({ content: 'やば' }),
+      };
+
+      const llmService = createReactionService(
+        db,
+        { useLLM: true },
+        mockLLMService as unknown as Parameters<typeof createReactionService>[2],
+      );
+
+      // Insert additional test entries
+      db.prepare(
+        `INSERT INTO entries (id, timestamp, content, metadata, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run('entry-2', Date.now() / 1000, 'Content 2', '{}', Date.now() / 1000, Date.now() / 1000);
+
+      // First reaction has no recent reaction history
+      await llmService.generateReaction('entry-1', 'test content');
+      expect(mockLLMService.react).toHaveBeenLastCalledWith(
+        'test content',
+        expect.objectContaining({ recentReactions: undefined }),
+      );
+
+      // Second reaction should include the first reaction in recent list
+      await llmService.generateReaction('entry-2', 'more content');
+      expect(mockLLMService.react).toHaveBeenLastCalledWith(
+        'more content',
+        expect.objectContaining({ recentReactions: ['やば'] }),
+      );
     });
   });
 });

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -31,6 +31,8 @@ const DEFAULT_CONFIG: ReactionConfig = {
   useLLM: true,
 };
 
+const RECENT_REACTION_LIMIT = 8;
+
 /**
  * Reaction content templates aligned with mumbl personality
  */
@@ -84,6 +86,7 @@ export function createReactionService(
   const entryRepository = createEntryRepository(db);
   let currentConfig: ReactionConfig = { ...DEFAULT_CONFIG, ...config };
   let vocabulary: VocabularySet | undefined;
+  const recentReactions: string[] = [];
 
   const setVocabulary = (v: VocabularySet): void => {
     vocabulary = v;
@@ -151,7 +154,11 @@ export function createReactionService(
           .filter((e) => e.id !== entryId)
           .slice(0, 5)
           .map((e) => e.content);
-        const response = await llmService.react(content, { language, recentEntries });
+        const response = await llmService.react(content, {
+          language,
+          recentEntries,
+          recentReactions: recentReactions.length > 0 ? [...recentReactions] : undefined,
+        });
         const trimmed = response.content.trim();
         // Use LLM response if non-empty and short enough for a one-word reaction
         if (trimmed && trimmed.length <= MAX_REACTION_LENGTH) {
@@ -175,6 +182,12 @@ export function createReactionService(
       content: reactionContent,
       createdAt: new Date(),
     };
+
+    // Track recent reactions for deduplication
+    recentReactions.push(reactionContent);
+    if (recentReactions.length > RECENT_REACTION_LIMIT) {
+      recentReactions.shift();
+    }
 
     repository.insert(reaction);
     emit('reactionCreated', reaction);


### PR DESCRIPTION
## Summary

Implements issue #132 by tracking recent reactions in memory and injecting a "do not repeat" list into the LLM prompt.

Depends on: #133 (issue #130), #134 (issue #131)

- Track last 8 reactions in an in-memory ring buffer
- Inject "Do NOT repeat these recent reactions: X, Y, Z" into the prompt
- Pass recentReactions from reaction-service through to LLM

## Changes

- **src/services/llm/prompts.ts**: Add `recentReactions` to `ReactionPromptOptions`, inject dedup block
- **src/services/reaction-service.ts**: Add ring buffer tracking, pass recent reactions to LLM
- **src/services/llm/prompts.test.ts**: Add dedup prompt injection tests
- **src/services/reaction-service.test.ts**: Add reaction tracking integration test

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 727 tests pass
- [x] `pnpm ci:all` passes (pre-push hook)