### PR TITLE
Improve prompt consistency and localize Japanese headers

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -437,10 +437,10 @@ describe('sampleVocabularyForReaction', () => {
     });
     const systemContent = messages[0]?.content ?? '';
 
-    expect(systemContent).toContain('Previous mumbles');
+    expect(systemContent).toContain('前のつぶやき');
     expect(systemContent).toContain('1. 長い一日だった');
     expect(systemContent).toContain('2. 仕事がきつかった');
-    expect(systemContent).toContain('DO NOT mention or reference their content');
+    expect(systemContent).toContain('内容には触れないこと');
   });
 });
 

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -276,7 +276,7 @@ function buildRecentEntriesContext(recentEntries: string[], language?: DetectedL
   const entriesText = recentEntries.map((e, i) => `${i + 1}. ${e}`).join('\n');
   const header =
     language === 'ja'
-      ? '\n\n## Previous mumbles (mood reference ONLY - DO NOT mention or reference their content in your reaction):'
+      ? '\n\n## 前のつぶやき (雰囲気の参考のみ - 内容には触れないこと):'
       : '\n\n## Previous mumbles (mood reference ONLY - DO NOT mention or reference their content in your reaction):';
   return `${header}\n${entriesText}`;
 }
@@ -345,7 +345,10 @@ function buildVocabularyPrioritySection(
   const phrases = samplePhrasesForReaction(vocabulary);
   if (words.length === 0 && phrases.length === 0) return '';
 
-  const header = '## YOUR VOCABULARY (ACTIVELY USE THESE):';
+  const header =
+    language === 'ja'
+      ? '## あなたのボキャブラリー (積極的に使って):'
+      : '## YOUR VOCABULARY (ACTIVELY USE THESE):';
   const parts: string[] = [header];
   if (words.length > 0) {
     parts.push(`Words: ${words.join(', ')}`);
@@ -364,7 +367,7 @@ How to use vocabulary:
 - Vocab word as exclamation: "wavy!", "real"
 - Vocab word in short phrase: "それwavy", "まじfly"
 
-Keep reactions SHORT (1-3 words). Do NOT write full sentences or explanations.
+Keep reactions SHORT (1-5 words). Do NOT write full sentences or explanations.
 The reaction must relate to the entry - but vocabulary words are flexible enough to fit most moods.
 Only skip vocabulary if the entry is so mundane that ANY word feels forced (e.g. "うん" or "·" is enough).
 
@@ -383,7 +386,7 @@ How to use vocabulary:
 - Vocab word as exclamation: "wavy!", "real"
 - Vocab word in short phrase: "that's wavy", "big drip"
 
-Keep reactions SHORT (1-3 words). Do NOT write full sentences or explanations.
+Keep reactions SHORT (1-5 words). Do NOT write full sentences or explanations.
 The reaction must relate to the entry - but vocabulary words are flexible enough to fit most moods.
 Only skip vocabulary if the entry is so mundane that ANY word feels forced (e.g. "word" or "·" is enough).
 
@@ -428,7 +431,7 @@ export function createReactionPrompt(
 
   const examples =
     language === 'ja'
-      ? `Examples (most are one word, "·" is rare):
+      ? `Examples (vary between words, short phrases, and "·"):
 "コーヒー飲んだ" -> な
 "帰った" -> おけ
 "天気いい" -> よき
@@ -446,7 +449,7 @@ export function createReactionPrompt(
 "テスト全部通った" -> ナイス
 "転職考えてる" -> まじか
 "子供が初めて歩いた" -> すげー`
-      : `Examples (most are one word, "·" is rare):
+      : `Examples (vary between words, short phrases, and "·"):
 "had coffee" -> cool
 "home" -> bet
 "nice weather" -> valid
@@ -494,11 +497,11 @@ export function createReactionPrompt(
   const dedupBlock =
     recentReactions.length > 0
       ? `\n## DEDUP (STRICTLY ENFORCED):
-You already used these reactions recently. NEVER repeat them or say anything similar.
-Each reaction below is BANNED - do not reuse ANY part of these phrases:
+You already used these reactions recently. NEVER reuse the exact same reaction or a close paraphrase.
+Each reaction below is BANNED:
 ${recentReactions.map((r, i) => `${i + 1}. "${r}" <- BANNED`).join('\n')}
 
-Your new reaction MUST be completely different in wording, structure, and meaning from ALL of the above.\n`
+Your new reaction MUST be completely different in wording from ALL of the above.\n`
       : '';
 
   const vocabInstruction = vocabSection ? `\n${vocabSection}\n` : '';


### PR DESCRIPTION
## Summary

Implements issue #138. Fix contradictions and improve clarity in reaction prompts based on two external reviews.

- Fix "·" frequency contradiction (response modes say ~25%, examples said "rare")
- Align vocabulary word count from "1-3 words" to "1-5 words" matching response mode spec
- Localize headers for Japanese mode in `buildVocabularyPrioritySection` and `buildRecentEntriesContext`
- Relax DEDUP rules from "different in meaning" to "different in wording"

## Changes

- **src/services/llm/prompts.ts**: 7 string changes across 4 areas (examples header, vocabulary word count, Japanese headers, DEDUP block)
- **src/services/llm/prompts.test.ts**: Update 2 Japanese test assertions for localized headers

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (739 tests, 51 files)
- [x] `pnpm lint` passes
- [x] Pre-push `ci:all` passes with coverage