### PR TITLE
Add initial setup wizard for first-time Ollama configuration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import * as fs from 'node:fs';
 import { render } from 'ink';
 import React from 'react';
+import { getConfigFilePath } from './config/config-file.js';
 import { resolveConfig } from './config/index.js';
 import { getReactionConfig } from './infrastructure/config/reaction-config.js';
 import { closeDatabase, getDatabase } from './infrastructure/database/client.js';
@@ -35,6 +37,9 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
     console.log('Note: Interactive mode requires a TTY. Run in a terminal for full experience.');
     process.exit(0);
   }
+
+  // Check if this is the first run (no config file exists)
+  const needsSetup = !fs.existsSync(getConfigFilePath());
 
   // Resolve configuration with priority: CLI > Environment > Config file > Default
   const config = resolveConfig();
@@ -95,7 +100,7 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
     >
       <QueueProvider queueService={queueService}>
         <ConfigProvider config={config}>
-          <App />
+          <App needsSetup={needsSetup} />
         </ConfigProvider>
       </QueueProvider>
     </ServiceProvider>,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,6 +6,7 @@ import { HelpFooter } from './components/common/HelpFooter.js';
 import { ModeIndicator } from './components/common/ModeIndicator.js';
 import { ConfigView } from './components/config/ConfigView.js';
 import { EntryList } from './components/entries/EntryList.js';
+import { SetupWizard } from './components/setup/SetupWizard.js';
 import { SplashScreen } from './components/splash/SplashScreen.js';
 import { WriteView } from './components/write/WriteView.js';
 import { NavigationProvider, useNavigation } from './context/NavigationContext.js';
@@ -56,8 +57,17 @@ function AppContent() {
   );
 }
 
-export function App() {
+interface AppProps {
+  needsSetup?: boolean;
+}
+
+export function App({ needsSetup = false }: AppProps) {
+  const [showSetup, setShowSetup] = useState(needsSetup);
   const [showSplash, setShowSplash] = useState(true);
+
+  if (showSetup) {
+    return <SetupWizard onComplete={() => setShowSetup(false)} />;
+  }
 
   if (showSplash) {
     return <SplashScreen onComplete={() => setShowSplash(false)} />;

--- a/src/ui/components/setup/SetupWizard.test.tsx
+++ b/src/ui/components/setup/SetupWizard.test.tsx
@@ -1,0 +1,203 @@
+import { cleanup, render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SetupWizard } from './SetupWizard.js';
+
+vi.mock('../../../infrastructure/ollama/client.js', () => ({
+  checkOllamaHealth: vi.fn(),
+  listModels: vi.fn(),
+}));
+
+vi.mock('../../../config/config-file.js', () => ({
+  saveConfigFile: vi.fn(),
+}));
+
+import { checkOllamaHealth, listModels } from '../../../infrastructure/ollama/client.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SetupWizard', () => {
+  it('should show checking message initially', () => {
+    vi.mocked(checkOllamaHealth).mockReturnValue(new Promise(() => {}));
+    const onComplete = vi.fn();
+
+    const { lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    expect(lastFrame()).toContain('Checking Ollama connection');
+  });
+
+  it('should show not-connected state when Ollama is down', async () => {
+    vi.mocked(checkOllamaHealth).mockResolvedValue({
+      isConnected: false,
+      baseUrl: 'http://127.0.0.1:11434',
+      error: 'Connection refused',
+    });
+    const onComplete = vi.fn();
+
+    const { lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Could not connect to Ollama');
+    });
+
+    expect(lastFrame()).toContain('Connection refused');
+    expect(lastFrame()).toContain('brew install ollama');
+    expect(lastFrame()).toContain('ollama serve');
+    expect(lastFrame()).toContain('ollama pull llama3.1:8b');
+  });
+
+  it('should show model selection when connected with models', async () => {
+    vi.mocked(checkOllamaHealth).mockResolvedValue({
+      isConnected: true,
+      baseUrl: 'http://127.0.0.1:11434',
+    });
+    vi.mocked(listModels).mockResolvedValue([
+      {
+        name: 'llama3.1:8b',
+        modifiedAt: new Date(),
+        size: 4_500_000_000,
+        digest: 'abc123',
+        details: {
+          format: 'gguf',
+          family: 'llama',
+          parameterSize: '8B',
+          quantizationLevel: 'Q4_0',
+        },
+      },
+      {
+        name: 'qwen2.5-coder:7b',
+        modifiedAt: new Date(),
+        size: 3_800_000_000,
+        digest: 'def456',
+        details: {
+          format: 'gguf',
+          family: 'qwen2',
+          parameterSize: '7B',
+          quantizationLevel: 'Q4_0',
+        },
+      },
+    ]);
+    const onComplete = vi.fn();
+
+    const { lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Connected to Ollama');
+    });
+
+    expect(lastFrame()).toContain('Select a model');
+    expect(lastFrame()).toContain('llama3.1:8b');
+    expect(lastFrame()).toContain('qwen2.5-coder:7b');
+  });
+
+  it('should show no models message when connected but no models installed', async () => {
+    vi.mocked(checkOllamaHealth).mockResolvedValue({
+      isConnected: true,
+      baseUrl: 'http://127.0.0.1:11434',
+    });
+    vi.mocked(listModels).mockResolvedValue([]);
+    const onComplete = vi.fn();
+
+    const { lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('No models installed');
+    });
+
+    expect(lastFrame()).toContain('ollama pull llama3.1:8b');
+  });
+
+  it('should call onComplete when skip is pressed on not-connected', async () => {
+    vi.mocked(checkOllamaHealth).mockResolvedValue({
+      isConnected: false,
+      baseUrl: 'http://127.0.0.1:11434',
+    });
+    const onComplete = vi.fn();
+
+    const { stdin } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    // Wait for not-connected state
+    await new Promise((r) => setTimeout(r, 50));
+
+    stdin.write('s');
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('should retry connection when r is pressed', async () => {
+    let callCount = 0;
+    vi.mocked(checkOllamaHealth).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { isConnected: false, baseUrl: 'http://127.0.0.1:11434', error: 'Refused' };
+      }
+      return { isConnected: true, baseUrl: 'http://127.0.0.1:11434' };
+    });
+    vi.mocked(listModels).mockResolvedValue([
+      {
+        name: 'llama3.1:8b',
+        modifiedAt: new Date(),
+        size: 4_500_000_000,
+        digest: 'abc',
+      },
+    ]);
+    const onComplete = vi.fn();
+
+    const { stdin, lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Could not connect');
+    });
+
+    stdin.write('r');
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Select a model');
+    });
+
+    expect(checkOllamaHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('should save config and call onComplete when model is selected', async () => {
+    const { saveConfigFile } = await import('../../../config/config-file.js');
+    vi.mocked(checkOllamaHealth).mockResolvedValue({
+      isConnected: true,
+      baseUrl: 'http://127.0.0.1:11434',
+    });
+    vi.mocked(listModels).mockResolvedValue([
+      {
+        name: 'llama3.1:8b',
+        modifiedAt: new Date(),
+        size: 4_500_000_000,
+        digest: 'abc',
+      },
+    ]);
+    const onComplete = vi.fn();
+
+    const { stdin, lastFrame } = render(<SetupWizard onComplete={onComplete} />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Select a model');
+    });
+
+    stdin.write('\r');
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith('llama3.1:8b');
+    });
+
+    expect(saveConfigFile).toHaveBeenCalledWith({ model: 'llama3.1:8b' });
+  });
+});

--- a/src/ui/components/setup/SetupWizard.tsx
+++ b/src/ui/components/setup/SetupWizard.tsx
@@ -1,0 +1,210 @@
+import { Box, Text, useApp, useInput } from 'ink';
+import React, { useCallback, useEffect, useState } from 'react';
+import { saveConfigFile } from '../../../config/config-file.js';
+import { checkOllamaHealth, listModels } from '../../../infrastructure/ollama/client.js';
+import type { OllamaModel } from '../../../infrastructure/ollama/types.js';
+import { Logo } from '../splash/Logo.js';
+
+type WizardStep = 'checking' | 'not-connected' | 'select-model' | 'complete';
+
+interface SetupWizardProps {
+  onComplete: (model?: string) => void;
+}
+
+export function SetupWizard({ onComplete }: SetupWizardProps) {
+  const { exit } = useApp();
+  const [step, setStep] = useState<WizardStep>('checking');
+  const [models, setModels] = useState<OllamaModel[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [error, setError] = useState<string | undefined>();
+
+  const checkConnection = useCallback(async () => {
+    setStep('checking');
+    setError(undefined);
+
+    const health = await checkOllamaHealth();
+
+    if (!health.isConnected) {
+      setError(health.error);
+      setStep('not-connected');
+      return;
+    }
+
+    try {
+      const available = await listModels();
+      if (available.length === 0) {
+        setModels([]);
+        setStep('select-model');
+        return;
+      }
+      setModels(available);
+      setStep('select-model');
+    } catch {
+      setModels([]);
+      setStep('select-model');
+    }
+  }, []);
+
+  useEffect(() => {
+    checkConnection();
+  }, [checkConnection]);
+
+  useInput((input, key) => {
+    if (input === 'q' || (key.ctrl && input === 'c')) {
+      exit();
+      return;
+    }
+
+    if (step === 'not-connected') {
+      if (input === 'r') {
+        checkConnection();
+        return;
+      }
+      if (input === 's') {
+        onComplete();
+        return;
+      }
+    }
+
+    if (step === 'select-model') {
+      if (models.length > 0) {
+        if (input === 'j' || key.downArrow) {
+          setSelectedIndex((prev) => Math.min(prev + 1, models.length - 1));
+          return;
+        }
+        if (input === 'k' || key.upArrow) {
+          setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          return;
+        }
+        if (key.return) {
+          const selected = models[selectedIndex];
+          if (selected) {
+            saveConfigFile({ model: selected.name });
+            onComplete(selected.name);
+          }
+          return;
+        }
+      }
+      if (input === 's') {
+        onComplete();
+        return;
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Logo />
+      <Box marginTop={1} flexDirection="column">
+        {step === 'checking' && <CheckingStep />}
+        {step === 'not-connected' && <NotConnectedStep error={error} />}
+        {step === 'select-model' && (
+          <SelectModelStep models={models} selectedIndex={selectedIndex} />
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function CheckingStep() {
+  return (
+    <Box flexDirection="column">
+      <Text color="cyan">Checking Ollama connection...</Text>
+    </Box>
+  );
+}
+
+function NotConnectedStep({ error }: { error?: string }) {
+  return (
+    <Box flexDirection="column">
+      <Text color="red" bold>
+        Could not connect to Ollama
+      </Text>
+      {error && (
+        <Box marginTop={1} paddingLeft={2}>
+          <Text dimColor>{error}</Text>
+        </Box>
+      )}
+      <Box marginTop={1} flexDirection="column" paddingLeft={2}>
+        <Text>To get started, install and run Ollama:</Text>
+        <Box marginTop={1} flexDirection="column" paddingLeft={2}>
+          <Text dimColor>1. Install: </Text>
+          <Text color="green"> brew install ollama</Text>
+          <Text dimColor>2. Start: </Text>
+          <Text color="green"> ollama serve</Text>
+          <Text dimColor>3. Pull a model: </Text>
+          <Text color="green"> ollama pull llama3.1:8b</Text>
+        </Box>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>[r] retry [s] skip [q] quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function formatSize(bytes: number): string {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+}
+
+function SelectModelStep({
+  models,
+  selectedIndex,
+}: {
+  models: OllamaModel[];
+  selectedIndex: number;
+}) {
+  if (models.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text color="green">Connected to Ollama</Text>
+        <Box marginTop={1}>
+          <Text color="yellow">No models installed.</Text>
+        </Box>
+        <Box marginTop={1} flexDirection="column" paddingLeft={2}>
+          <Text>Pull a model to get started:</Text>
+          <Box marginTop={1}>
+            <Text color="green"> ollama pull llama3.1:8b</Text>
+          </Box>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[s] skip [q] quit</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Connected to Ollama</Text>
+      <Box marginTop={1}>
+        <Text bold>Select a model:</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column" paddingLeft={2}>
+        {models.map((model, i) => {
+          const isSelected = i === selectedIndex;
+          const prefix = isSelected ? '>' : ' ';
+          const size = model.size ? ` (${formatSize(model.size)})` : '';
+          const params = model.details?.parameterSize ? ` [${model.details.parameterSize}]` : '';
+          return (
+            <Text key={model.name} color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+              {prefix} {model.name}
+              <Text dimColor>
+                {params}
+                {size}
+              </Text>
+            </Text>
+          );
+        })}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>[j/k] navigate [Enter] select [s] skip [q] quit</Text>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Implements issue #141 - Add a setup wizard that guides first-time users through Ollama connection and model selection.

- Shows on first launch when no config file exists
- Checks Ollama connectivity and lists available models
- Guides users through installation if Ollama is not running
- Saves selected model to config file

## Changes

- **src/ui/components/setup/SetupWizard.tsx**: New wizard component with three steps - connection check, not-connected guide, and model selection
- **src/ui/components/setup/SetupWizard.test.tsx**: Comprehensive tests for all wizard states and user interactions (7 tests)
- **src/ui/App.tsx**: Add `needsSetup` prop and render wizard before splash screen when needed
- **src/index.tsx**: Detect first run by checking config file existence, pass `needsSetup` to App

## Test plan

- [x] Type-check passes
- [x] Biome lint passes
- [x] All 746 tests pass (7 new wizard tests)
- [x] 85% code coverage maintained
- [x] Wizard shows connection checking state
- [x] Wizard shows not-connected state with setup instructions
- [x] Wizard shows model selection when connected
- [x] Wizard shows no-models message when none installed
- [x] Skip (s), retry (r), and model selection (Enter) work correctly
- [x] Config file is saved when model is selected