### PR TITLE
Add CI workflow for automated npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run all checks
+        run: pnpm ci:all
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Implements issue #149 by adding a GitHub Actions workflow that automatically publishes to npm when a GitHub Release is created.

- Triggers on `release: published` event
- Runs full CI checks (`pnpm ci:all`) before publishing
- Enables npm provenance with `id-token: write` permission
- Uses `NPM_TOKEN` secret for authentication

## Changes

- **`.github/workflows/publish.yml`**: New workflow for automated npm publish

## Prerequisites (manual steps after merge)

- [ ] Generate npm Granular Access Token and add as `NPM_TOKEN` repository secret
- [ ] Create GitHub Release `v1.0.0` to trigger the first publish
- [ ] Verify with `npm info mumbl`

## Test plan

- [x] YAML syntax validated with yaml-lint
- [x] Workflow structure matches existing `ci.yml` patterns
- [ ] Create a GitHub Release and verify npm publish succeeds