### PR TITLE
Add explicit --tag latest to npm publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,6 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Ensure the package is always published with the `latest` dist-tag
to make the intent clear and prevent accidental non-latest releases.

https://claude.ai/code/session_01XZEjvRY4H5j6rJxWMQqYS9