### PR TITLE
Replace hardcoded wavy examples with dynamic vocabulary words

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -322,10 +322,31 @@ describe('createReactionPrompt', () => {
     const systemContent = messages[0]?.content ?? '';
 
     expect(systemContent).toContain('YOUR VOCABULARY (ACTIVELY USE THESE)');
-    expect(systemContent).toContain('YOUR VOCABULARY (ACTIVELY USE THESE)');
     expect(systemContent).toContain('Words: vibe, drip');
     expect(systemContent).toContain('Phrases: on god');
     expect(systemContent).toContain('ACTIVELY USE THESE');
+  });
+
+  it('should use actual vocabulary words in examples, not hardcoded words', () => {
+    const messages = createReactionPrompt('test', { language: 'en' }, testVocabulary);
+    const systemContent = messages[0]?.content ?? '';
+
+    // Dynamic examples should use actual vocab words
+    expect(systemContent).toContain('so vibe');
+    expect(systemContent).toContain('not vibe');
+    expect(systemContent).not.toContain('so wavy');
+    expect(systemContent).not.toContain('not wavy');
+  });
+
+  it('should use actual vocabulary words in Japanese examples', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' }, testVocabulary);
+    const systemContent = messages[0]?.content ?? '';
+
+    // Dynamic examples should use actual vocab words
+    expect(systemContent).toContain('vibeだな');
+    expect(systemContent).toContain('vibeじゃないな');
+    expect(systemContent).not.toContain('wavyだな');
+    expect(systemContent).not.toContain('wavyじゃない');
   });
 
   it('should include mood mapping even when vocabulary is provided', () => {

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -337,6 +337,17 @@ export function samplePhrasesForReaction(
  * When vocabulary is available, it's given prominent placement.
  * Instructs the LLM to weave vocabulary into short contextual phrases.
  */
+/**
+ * Pick example words from the sampled vocabulary for prompt examples.
+ * Returns up to 3 distinct words, reusing the first if fewer are available.
+ */
+function pickExampleWords(words: string[]): [string, string, string] {
+  const w1 = words[0] ?? 'vibe';
+  const w2 = words[1] ?? w1;
+  const w3 = words[2] ?? w2;
+  return [w1, w2, w3];
+}
+
 function buildVocabularyPrioritySection(
   vocabulary: VocabularySet,
   language?: DetectedLanguage,
@@ -356,45 +367,48 @@ function buildVocabularyPrioritySection(
   if (phrases.length > 0) {
     parts.push(`Phrases: ${phrases.join(', ')}`);
   }
+
+  const [w1, w2, w3] = pickExampleWords(words);
+
   const instruction =
     language === 'ja'
       ? `You SHOULD use these vocabulary words in most reactions. They are your signature style.
 Use them as building blocks: combine with particles, slang, or short phrases to react.
 
 How to use vocabulary:
-- Use a vocab word + particle/suffix: "wavyだな", "realすぎ", "やばいわ"
-- Negate a vocab word: "wavyじゃない", "全然fly"
-- Vocab word as exclamation: "wavy!", "real"
-- Vocab word in short phrase: "それwavy", "まじfly"
+- Use a vocab word + particle/suffix: "${w1}だな", "${w2}すぎ", "やばいわ"
+- Negate a vocab word: "${w1}じゃない", "全然${w2}"
+- Vocab word as exclamation: "${w1}!", "${w3}"
+- Vocab word in short phrase: "それ${w1}", "まじ${w2}"
 
 Keep reactions SHORT (1-5 words). Do NOT write full sentences or explanations.
 The reaction must relate to the entry - but vocabulary words are flexible enough to fit most moods.
 Only skip vocabulary if the entry is so mundane that ANY word feels forced (e.g. "うん" or "·" is enough).
 
 Examples:
-- "疲れた" -> "wavyじゃないな"
+- "疲れた" -> "${w1}じゃないな"
 - "昇進した！" -> "飛ぶわそれ"
-- "まじかー" -> "real"
-- "wavy?" -> "ちょうwavy"
+- "まじかー" -> "${w2}"
+- "${w1}?" -> "ちょう${w1}"
 - "ファミチキくいて" -> "わかる" (mundane, vocab not needed)`
       : `You SHOULD use these vocabulary words in most reactions. They are your signature style.
 Use them as building blocks: combine with particles, slang, or short phrases to react.
 
 How to use vocabulary:
-- Use a vocab word + modifier: "so wavy", "too real", "mad fly"
-- Negate a vocab word: "not wavy", "zero drip"
-- Vocab word as exclamation: "wavy!", "real"
-- Vocab word in short phrase: "that's wavy", "big drip"
+- Use a vocab word + modifier: "so ${w1}", "too ${w2}", "mad ${w3}"
+- Negate a vocab word: "not ${w1}", "zero ${w2}"
+- Vocab word as exclamation: "${w1}!", "${w2}"
+- Vocab word in short phrase: "that's ${w1}", "big ${w2}"
 
 Keep reactions SHORT (1-5 words). Do NOT write full sentences or explanations.
 The reaction must relate to the entry - but vocabulary words are flexible enough to fit most moods.
 Only skip vocabulary if the entry is so mundane that ANY word feels forced (e.g. "word" or "·" is enough).
 
 Examples:
-- "tired" -> "not wavy"
-- "got promoted!" -> "that's fly"
-- "for real?" -> "real"
-- "wavy?" -> "so wavy"
+- "tired" -> "not ${w1}"
+- "got promoted!" -> "that's ${w2}"
+- "for real?" -> "${w3}"
+- "${w1}?" -> "so ${w1}"
 - "want fried chicken" -> "same" (mundane, vocab not needed)`;
   parts.push(instruction);
   return parts.join('\n');


### PR DESCRIPTION
## Summary

Fixes #158. `buildVocabularyPrioritySection()` in `prompts.ts` hardcoded "wavy" in all vocabulary usage examples (14 occurrences), causing the LLM to overuse the word regardless of which wordgrain files were loaded. Even after deleting the JP The Wavy wordgrain, any other active wordgrain would trigger the wavy-heavy examples.

- Add `pickExampleWords()` helper to select example words from sampled vocabulary
- Update `buildVocabularyPrioritySection()` to dynamically generate examples using actual vocabulary words
- Add tests verifying dynamic examples use actual vocab words and no hardcoded "wavy" leaks

## Changes

- **src/services/llm/prompts.ts**: Add `pickExampleWords()`, refactor `buildVocabularyPrioritySection()` to use dynamic vocabulary in both JA and EN example templates
- **src/services/llm/prompts.test.ts**: Add 2 new tests for dynamic vocab examples (EN + JA)

## Test plan

- [x] All 717 unit tests pass
- [x] Type check passes
- [x] Biome lint passes
- [x] New tests verify vocabulary examples use actual vocab words (e.g. "vibe", "drip") not "wavy"
- [x] New tests verify "wavy" does not appear in prompt when vocabulary doesn't include it