### PR TITLE
Fix overused sugidaro pattern in Japanese reaction prompts

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -349,6 +349,14 @@ describe('createReactionPrompt', () => {
     expect(systemContent).not.toContain('wavyじゃない');
   });
 
+  it('should instruct to vary grammatical patterns in Japanese vocabulary section', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' }, testVocabulary);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Vary your grammatical patterns');
+    expect(systemContent).not.toContain('すぎ"');
+  });
+
   it('should include mood mapping even when vocabulary is provided', () => {
     const messages = createReactionPrompt('test', { language: 'en' }, testVocabulary);
     const systemContent = messages[0]?.content ?? '';

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -376,10 +376,12 @@ function buildVocabularyPrioritySection(
 Use them as building blocks: combine with particles, slang, or short phrases to react.
 
 How to use vocabulary:
-- Use a vocab word + particle/suffix: "${w1}だな", "${w2}すぎ", "やばいわ"
+- Vocab word + particle: "${w1}だな", "${w2}じゃん", "${w3}よな"
 - Negate a vocab word: "${w1}じゃない", "全然${w2}"
 - Vocab word as exclamation: "${w1}!", "${w3}"
 - Vocab word in short phrase: "それ${w1}", "まじ${w2}"
+
+IMPORTANT: Vary your grammatical patterns. Do NOT repeat the same suffix (e.g. すぎだろ, すぎるわ) across reactions. Use diverse endings: だな, じゃん, よな, わ, な, かよ, etc.
 
 Keep reactions SHORT (1-5 words). Do NOT write full sentences or explanations.
 The reaction must relate to the entry - but vocabulary words are flexible enough to fit most moods.
@@ -390,6 +392,7 @@ Examples:
 - "昇進した！" -> "飛ぶわそれ"
 - "まじかー" -> "${w2}"
 - "${w1}?" -> "ちょう${w1}"
+- "コーヒー飲みすぎた" -> "まあ${w3}だな"
 - "ファミチキくいて" -> "わかる" (mundane, vocab not needed)`
       : `You SHOULD use these vocabulary words in most reactions. They are your signature style.
 Use them as building blocks: combine with particles, slang, or short phrases to react.


### PR DESCRIPTION
## Summary

Fixes issue #160. The reaction prompt vocabulary section was teaching the LLM a `すぎ` suffix pattern (`"${w2}すぎ"`) that caused repetitive reactions like "awすぎだろ", "コーヒーすぎだろ！", "まわりすぎだろ！".

- Replace `すぎ` pattern with diverse suffix examples (`じゃん`, `よな`)
- Add explicit instruction to vary grammatical patterns across reactions
- Add test verifying the diversity instruction is present

## Changes

- **src/services/llm/prompts.ts**: Replace `"${w2}すぎ"` with `"${w2}じゃん", "${w3}よな"` in vocabulary usage examples. Add IMPORTANT instruction block telling the LLM to vary suffix patterns. Add a new diverse example reaction.
- **src/services/llm/prompts.test.ts**: Add test asserting the vary-patterns instruction exists and that `すぎ` is no longer in the vocabulary examples.

## Test plan

- [x] All 73 prompts.test.ts tests pass
- [x] Full ci:all passes (type-check + lint + tests)
- [ ] Verify in-app that reactions no longer repeat the すぎだろ pattern