### PR TITLE
Fix list mode scroll flickering

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { JournalEntry } from '../../../repositories/types.js';
 import { useNavigation } from '../../context/NavigationContext.js';
 import { useEntries } from '../../hooks/useEntries.js';
@@ -91,10 +91,20 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
         setViewingEntry(selectedEntry);
       }
     },
-    onIndexChange: (index) => {
-      setListState({ selectedIndex: index });
-    },
   });
+
+  // Track current index in a ref so we can save it to context on unmount
+  const selectedIndexRef = useRef(resolvedInitialIndex);
+  useEffect(() => {
+    selectedIndexRef.current = selectedIndex;
+  }, [selectedIndex]);
+
+  // Save selected index to context when leaving list mode (unmount)
+  useEffect(() => {
+    return () => {
+      setListState({ selectedIndex: selectedIndexRef.current });
+    };
+  }, [setListState]);
 
   // When entries load and sentinel was set, update to last entry
   useEffect(() => {

--- a/src/ui/context/NavigationContext.tsx
+++ b/src/ui/context/NavigationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 export type AppMode = 'list' | 'write' | 'config';
 
@@ -64,21 +64,20 @@ export function NavigationProvider({ children, initialMode = 'write' }: Navigati
     setMode((current) => (current === 'list' ? 'write' : 'list'));
   }, []);
 
-  return (
-    <NavigationContext.Provider
-      value={{
-        mode,
-        switchToList,
-        switchToWrite,
-        switchToConfig,
-        toggleMode,
-        listState,
-        setListState,
-        writeState,
-        setWriteState,
-      }}
-    >
-      {children}
-    </NavigationContext.Provider>
+  const value = useMemo(
+    () => ({
+      mode,
+      switchToList,
+      switchToWrite,
+      switchToConfig,
+      toggleMode,
+      listState,
+      setListState,
+      writeState,
+      setWriteState,
+    }),
+    [mode, switchToList, switchToWrite, switchToConfig, toggleMode, listState, writeState],
   );
+
+  return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>;
 }

--- a/src/ui/hooks/useKeyboardNavigation.ts
+++ b/src/ui/hooks/useKeyboardNavigation.ts
@@ -1,5 +1,5 @@
 import { useInput } from 'ink';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 export interface UseKeyboardNavigationOptions {
   itemCount: number;
@@ -8,7 +8,6 @@ export interface UseKeyboardNavigationOptions {
   onSelect?: (index: number) => void;
   onAction?: () => void;
   onEscape?: () => void;
-  onIndexChange?: (index: number) => void;
 }
 
 export interface UseKeyboardNavigationResult {
@@ -19,36 +18,30 @@ export interface UseKeyboardNavigationResult {
 export function useKeyboardNavigation(
   options: UseKeyboardNavigationOptions,
 ): UseKeyboardNavigationResult {
-  const {
-    itemCount,
-    enabled = true,
-    initialIndex = 0,
-    onSelect,
-    onAction,
-    onEscape,
-    onIndexChange,
-  } = options;
-  const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+  const { itemCount, enabled = true, initialIndex = 0, onSelect, onAction, onEscape } = options;
+  const [selectedIndex, setSelectedIndexState] = useState(initialIndex);
+  const selectedIndexRef = useRef(initialIndex);
+
+  const updateSelectedIndex = useCallback((index: number) => {
+    selectedIndexRef.current = index;
+    setSelectedIndexState(index);
+  }, []);
 
   const moveUp = useCallback(() => {
     if (itemCount === 0) return;
-    setSelectedIndex((prev) => {
-      const newIndex = prev > 0 ? prev - 1 : prev;
-      onSelect?.(newIndex);
-      onIndexChange?.(newIndex);
-      return newIndex;
-    });
-  }, [itemCount, onSelect, onIndexChange]);
+    const prev = selectedIndexRef.current;
+    const newIndex = prev > 0 ? prev - 1 : prev;
+    updateSelectedIndex(newIndex);
+    onSelect?.(newIndex);
+  }, [itemCount, onSelect, updateSelectedIndex]);
 
   const moveDown = useCallback(() => {
     if (itemCount === 0) return;
-    setSelectedIndex((prev) => {
-      const newIndex = prev < itemCount - 1 ? prev + 1 : prev;
-      onSelect?.(newIndex);
-      onIndexChange?.(newIndex);
-      return newIndex;
-    });
-  }, [itemCount, onSelect, onIndexChange]);
+    const prev = selectedIndexRef.current;
+    const newIndex = prev < itemCount - 1 ? prev + 1 : prev;
+    updateSelectedIndex(newIndex);
+    onSelect?.(newIndex);
+  }, [itemCount, onSelect, updateSelectedIndex]);
 
   useInput(
     (input, key) => {
@@ -79,6 +72,6 @@ export function useKeyboardNavigation(
 
   return {
     selectedIndex,
-    setSelectedIndex,
+    setSelectedIndex: updateSelectedIndex,
   };
 }


### PR DESCRIPTION
## Summary

Fixes issue #166 - Eliminates screen flickering when scrolling with j/k keys in list mode.

The root cause was two separate React render cycles per keypress: one from the local `selectedIndex` state update, and a second from updating `NavigationContext.listState` on every keypress, which recreated the unmemoized context value object and forced all consumers to re-render.

- Remove side effects from `useState` updater functions (React anti-pattern)
- Stop updating NavigationContext on every keypress; save index only on unmount
- Memoize NavigationContext provider value with `useMemo`

## Changes

- **`src/ui/hooks/useKeyboardNavigation.ts`**: Use ref-based index tracking; move `onSelect` callback outside the state updater; remove `onIndexChange` option
- **`src/ui/components/entries/EntryList.tsx`**: Remove `onIndexChange` usage; track index in a ref; save to context only on unmount (when leaving list mode)
- **`src/ui/context/NavigationContext.tsx`**: Wrap Provider value in `useMemo` to prevent unnecessary consumer re-renders

## Test plan

- [x] `pnpm type-check` passes
- [x] All 742 tests pass
- [x] Biome lint + format passes
- [ ] Manual: scroll rapidly with j/k in list mode - no flickering
- [ ] Manual: scroll to entry N, Tab to write, Tab back to list - selection preserved at entry N
- [ ] Manual: write new entry, auto-switch to list - first entry selected (sentinel -1 behavior)