### PR TITLE
Fix list mode scroll flickering with incremental rendering

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,6 +104,7 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
         </ConfigProvider>
       </QueueProvider>
     </ServiceProvider>,
+    { incrementalRendering: true },
   );
 
   await instance.waitUntilExit();

--- a/src/ui/components/entries/EntryGroupHeader.tsx
+++ b/src/ui/components/entries/EntryGroupHeader.tsx
@@ -7,7 +7,11 @@ interface EntryGroupHeaderProps {
   maxWidth?: number;
 }
 
-export function EntryGroupHeader({ groupName, entryCount, maxWidth = 60 }: EntryGroupHeaderProps) {
+export const EntryGroupHeader = React.memo(function EntryGroupHeader({
+  groupName,
+  entryCount,
+  maxWidth = 60,
+}: EntryGroupHeaderProps) {
   const prefixLength = 4 + groupName.length + 3 + String(entryCount).length + 2;
   const separatorLength = Math.max(3, maxWidth - prefixLength);
 
@@ -21,4 +25,4 @@ export function EntryGroupHeader({ groupName, entryCount, maxWidth = 60 }: Entry
       <Text dimColor>{'─'.repeat(separatorLength)}</Text>
     </Box>
   );
-}
+});

--- a/src/ui/components/entries/EntryListItem.tsx
+++ b/src/ui/components/entries/EntryListItem.tsx
@@ -27,7 +27,12 @@ export function formatReactionDisplay(reaction: Reaction): string {
   }
 }
 
-export function EntryListItem({ entry, isSelected, maxWidth = 60, reaction }: EntryListItemProps) {
+export const EntryListItem = React.memo(function EntryListItem({
+  entry,
+  isSelected,
+  maxWidth = 60,
+  reaction,
+}: EntryListItemProps) {
   const timestamp = formatEntryTimestamp(entry.timestamp);
   const timestampWidth = timestamp.length + 1; // +1 for space before timestamp
   const contentWidth = Math.max(10, maxWidth - timestampWidth - 2); // 2 for cursor "> "
@@ -55,4 +60,4 @@ export function EntryListItem({ entry, isSelected, maxWidth = 60, reaction }: En
       </Box>
     </Box>
   );
-}
+});


### PR DESCRIPTION
## Summary

Fixes #170 - Eliminates list mode scroll flickering (Part 2 of #168).

- Enable Ink's `incrementalRendering` to use line-by-line diffing instead of full-screen erase-and-rewrite
- Wrap `EntryListItem` and `EntryGroupHeader` with `React.memo` to skip re-rendering unchanged items

## Changes

- **src/index.tsx**: Add `{ incrementalRendering: true }` to `render()` call
- **src/ui/components/entries/EntryListItem.tsx**: Wrap with `React.memo`
- **src/ui/components/entries/EntryGroupHeader.tsx**: Wrap with `React.memo`

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm ci:check` passes (Biome lint)
- [x] `pnpm ci:test` passes (742 tests)
- [ ] Manual: scroll rapidly with j/k in list mode - no flickering
- [ ] Manual: scroll to entry N → Tab to write → Tab back → selection preserved
- [ ] Manual: write new entry → auto-switch to list → first entry selected