### PR TITLE
Fix list mode black flash caused by Ink clearTerminal fallback

### DIFF
--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -126,8 +126,16 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   // Get terminal size for viewport calculation
   const { rows: terminalRows, columns: terminalColumns } = useTerminalSize();
 
-  // Calculate viewport height: terminal rows - header (2 lines) - padding (2 lines) - footer reserve (3 lines)
-  const viewportHeight = Math.max(5, terminalRows - 7);
+  // Calculate viewport height: terminal rows minus all non-viewport UI lines.
+  // Ink clears the entire terminal when output height >= stdout.rows (ink.js:181),
+  // bypassing incrementalRendering. We must keep total output below terminal rows.
+  //
+  // Non-viewport overhead (10 lines):
+  //   App header:  padding-top(1) + content(1) + padding-bottom(1) + marginBottom(1) = 4
+  //   EntryList:   padding-top(1) + title(1) + title-marginBottom(1) + padding-bottom(1) = 4
+  //   Footer:      marginTop(1) + content(1) = 2
+  // Plus 1 line buffer to ensure total stays strictly below stdout.rows.
+  const viewportHeight = Math.max(5, terminalRows - 11);
 
   // Calculate max width: terminal columns - padding (1 char each side from Box padding={1})
   const listMaxWidth = Math.max(30, terminalColumns - 2);


### PR DESCRIPTION
## Summary

Fixes #173. The list mode screen was going completely black during j/k navigation because Ink's `clearTerminal` fallback was firing on every render.

- Correct viewport height calculation from `terminalRows - 7` to `terminalRows - 11`
- Accounts for actual UI overhead: header (4 lines) + EntryList (4 lines) + footer (2 lines) + 1 buffer

## Changes

- **src/ui/components/entries/EntryList.tsx**: Fix viewport height offset to keep total output below `stdout.rows`, allowing Ink's `incrementalRendering` to work correctly

## Root cause

Ink (`ink.js:181`) clears the entire terminal when output height >= terminal rows, completely bypassing `incrementalRendering`. The previous offset of 7 underestimated the actual non-viewport overhead (10 lines), so the output always exceeded the terminal by 3 lines.

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 742 unit tests pass
- [ ] Manual: run `mumbl`, switch to list mode, navigate with j/k - no black flash