### PR TITLE
Fix wordgrain loader to read top-level bars array in v0.2.0 format

### DIFF
--- a/src/services/wordgrain/wordgrain-loader.test.ts
+++ b/src/services/wordgrain/wordgrain-loader.test.ts
@@ -326,6 +326,57 @@ describe('parseWordgrainFile', () => {
     expect(result?.bars).toHaveLength(0);
   });
 
+  it('should parse v0.2.0 files with separate top-level bars array', () => {
+    const filePath = path.join(tmpDir, 'v020-bars.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        schema_version: '0.2.0',
+        meta: { artist: 'KOHH' },
+        grains: [
+          { word: 'cbd', frequency: 119, pos: 'noun' },
+          { word: 'money', frequency: 50, pos: 'noun' },
+        ],
+        bars: [
+          { text: 'line one', source: { track: 'Track A' } },
+          { text: 'line two', source: { track: 'Track B' } },
+          { text: 'line three' },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('KOHH');
+    expect(result?.type).toBe('mixed');
+    expect(result?.schemaVersion).toBe('0.2.0');
+    expect(result?.grains).toHaveLength(2);
+    expect(result?.bars).toHaveLength(3);
+    expect(result?.bars[0]?.text).toBe('line one');
+    expect(result?.bars[2]?.text).toBe('line three');
+  });
+
+  it('should parse v0.2.0 files with only top-level bars array and empty grains', () => {
+    const filePath = path.join(tmpDir, 'v020-bars-only.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        schema_version: '0.2.0',
+        meta: { artist: 'Test' },
+        grains: [],
+        bars: [{ text: 'bar one' }, { text: 'bar two' }],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('bar');
+    expect(result?.grains).toHaveLength(0);
+    expect(result?.bars).toHaveLength(2);
+  });
+
   it('should reject bar entries with non-string text', () => {
     const filePath = path.join(tmpDir, 'bad-bar.wg.json');
     fs.writeFileSync(

--- a/src/services/wordgrain/wordgrain-loader.ts
+++ b/src/services/wordgrain/wordgrain-loader.ts
@@ -117,7 +117,20 @@ export function parseWordgrainFile(filePath: string): WordgrainFile | null {
       }
     }
 
-    return { name, type: 'grain', schemaVersion, grains, bars: [] };
+    // v0.2.0: also read top-level "bars" array if present
+    const bars: Bar[] = [];
+    if (Array.isArray(record['bars'])) {
+      for (const item of record['bars']) {
+        if (isValidBar(item)) {
+          bars.push(item);
+        }
+      }
+    }
+
+    const resolvedType: WordgrainType =
+      bars.length > 0 && grains.length > 0 ? 'mixed' : bars.length > 0 ? 'bar' : 'grain';
+
+    return { name, type: resolvedType, schemaVersion, grains, bars };
   } catch {
     return null;
   }

--- a/src/ui/components/config/WordgrainSection.tsx
+++ b/src/ui/components/config/WordgrainSection.tsx
@@ -28,7 +28,12 @@ export function WordgrainSection() {
               <Text dimColor>
                 {' '}
                 ({file.filename},{' '}
-                {file.barCount > 0 ? `${file.barCount} bars` : `${file.grainCount} grains`})
+                {file.grainCount > 0 && file.barCount > 0
+                  ? `${file.grainCount} grains, ${file.barCount} bars`
+                  : file.barCount > 0
+                    ? `${file.barCount} bars`
+                    : `${file.grainCount} grains`}
+                )
               </Text>
             </Text>
           ))}


### PR DESCRIPTION
## Summary

Fixes #179 - The wordgrain loader ignored the top-level `bars` array in v0.2.0 format files (like barscan output). Only bars embedded in the `grains` array with explicit `type: 'bar'` or `type: 'mixed'` were read.

- Read top-level `record['bars']` in the default grain-type parsing path
- Auto-detect type as `mixed` or `bar` based on which arrays have content
- Display both grain and bar counts in UI when both exist

## Changes

- **src/services/wordgrain/wordgrain-loader.ts**: Read top-level `bars` array and auto-resolve type
- **src/ui/components/config/WordgrainSection.tsx**: Show both counts for mixed files (e.g. "2155 grains, 300 bars")
- **src/services/wordgrain/wordgrain-loader.test.ts**: Add 2 tests for top-level bars parsing

## Test plan

- [x] All 761 unit tests pass
- [x] Type check passes
- [x] Biome lint/format passes
- [ ] Load a v0.2.0 .wg.json file with separate grains and bars arrays, verify both counts display