### PR TITLE
Ban desu-masu forms and Japanese period from reactions

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -252,6 +252,31 @@ describe('createReactionPrompt', () => {
     expect(systemContent).not.toContain('"had coffee"');
   });
 
+  it('should ban desu-masu forms in Japanese reactions', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('ですます調');
+    expect(systemContent).toContain('タメ口');
+  });
+
+  it('should ban Japanese period in Japanese reactions', () => {
+    const messages = createReactionPrompt('テスト', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('。(Japanese period)');
+    expect(systemContent).toContain('never end with 。');
+  });
+
+  it('should not include Japanese-specific bans in English reactions', () => {
+    const messages = createReactionPrompt('test', { language: 'en' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).not.toContain('ですます調');
+    expect(systemContent).not.toContain('タメ口');
+    expect(systemContent).not.toContain('。(Japanese period)');
+  });
+
   it('should include new category examples for ja language', () => {
     const messages = createReactionPrompt('テスト', { language: 'ja' });
     const systemContent = messages[0]?.content ?? '';

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -552,7 +552,11 @@ function buildResponseModeSection(language?: DetectedLanguage): string {
 1. Short phrase, 1-5 words (~45% of the time): A casual reaction that feels natural.
 2. Single word (~25%): One word that captures the vibe.
 3. "·" (~25%): For mundane, low-energy, or routine entries. Just a read receipt.
-4. Short sentence (~5%, ONLY for highly emotional/significant entries).`;
+4. Short sentence (~5%, ONLY for highly emotional/significant entries).
+
+BANNED in Japanese:
+- ですます調 (です、ます、でした、ました) — use タメ口 only
+- 。(Japanese period) — never end with 。`;
   }
 
   return `## Response modes:


### PR DESCRIPTION
## Summary

Fixes #185. Adds explicit bans for ですます調 and 。(Japanese period) in reaction prompts to enforce casual tone.

- Add `BANNED in Japanese` block to `buildResponseModeSection()` for JA language
- Add 3 tests verifying bans appear in JA and are absent from EN prompts

## Changes

- **src/services/llm/prompts.ts**: Append ですます調 and 。 ban rules to JA branch of `buildResponseModeSection()`
- **src/services/llm/prompts.test.ts**: Add tests for desu-masu ban, period ban, and EN exclusion

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm check` passes
- [x] `pnpm test:coverage` passes (773 tests, all coverage thresholds met)