### PR TITLE
Fix vocabulary sentiment mismatch in reactions

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -3,6 +3,7 @@ import type { VocabularySet, VocabularyWord } from '../wordgrain/types.js';
 import {
   MUMBL_SYSTEM_PROMPT,
   buildBarReferenceSection,
+  buildSentimentHints,
   createCalloutPrompt,
   createChatMessages,
   createFollowUpEvaluationPrompt,
@@ -1061,5 +1062,106 @@ describe('createReactionPrompt with bars', () => {
     expect(systemContent).toContain('LYRIC REFERENCES');
     expect(systemContent).not.toContain('"snack was good" -> fire');
     expect(systemContent).not.toContain('Word/phrase reference');
+  });
+});
+
+describe('buildSentimentHints', () => {
+  it('should group words by sentiment', () => {
+    const words: VocabularyWord[] = [
+      { word: 'chill', sentiment: 'positive', sentimentScore: 0.8 },
+      { word: 'annoying', sentiment: 'negative', sentimentScore: -1.0 },
+      { word: 'great', sentiment: 'positive', sentimentScore: 0.9 },
+    ];
+    const hints = buildSentimentHints(words);
+
+    expect(hints).toHaveLength(2);
+    expect(hints).toContain('Positive-toned: chill, great');
+    expect(hints).toContain('Negative-toned: annoying');
+  });
+
+  it('should return empty array when no words have sentiment', () => {
+    const words: VocabularyWord[] = [{ word: 'plain' }, { word: 'basic' }];
+    const hints = buildSentimentHints(words);
+
+    expect(hints).toEqual([]);
+  });
+
+  it('should skip words without sentiment', () => {
+    const words: VocabularyWord[] = [{ word: 'chill', sentiment: 'positive' }, { word: 'plain' }];
+    const hints = buildSentimentHints(words);
+
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toBe('Positive-toned: chill');
+  });
+});
+
+describe('sentiment-matching rule in vocabulary usage', () => {
+  it('should include sentiment-matching rule for Japanese vocabulary', () => {
+    const vocab: VocabularySet = {
+      words: ['chill'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [{ word: 'chill' }],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'ja' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('NEVER use dismissive or negative words');
+    expect(systemContent).toContain('nostalgic');
+  });
+
+  it('should include sentiment-matching rule for English vocabulary', () => {
+    const vocab: VocabularySet = {
+      words: ['chill'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [{ word: 'chill' }],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('NEVER use dismissive or negative words');
+    expect(systemContent).toContain('nostalgic');
+  });
+
+  it('should include sentiment hints in prompt when vocabulary has sentiment data', () => {
+    const vocab: VocabularySet = {
+      words: ['annoying', 'great'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [
+        { word: 'annoying', sentiment: 'negative', sentimentScore: -1.0 },
+        { word: 'great', sentiment: 'positive', sentimentScore: 0.9 },
+      ],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Negative-toned: annoying');
+    expect(systemContent).toContain('Positive-toned: great');
+  });
+});
+
+describe('nostalgia mood category', () => {
+  it('should include nostalgia in Japanese mood mapping', () => {
+    const messages = createReactionPrompt('test', { language: 'ja' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Nostalgia');
+    expect(systemContent).toContain('なつかし');
+  });
+
+  it('should include nostalgia in English mood mapping', () => {
+    const messages = createReactionPrompt('test', { language: 'en' });
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Nostalgia');
+    expect(systemContent).toContain('takes me back');
   });
 });

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -455,6 +455,7 @@ How to use vocabulary:
 - You can transform, conjugate, or embed words naturally in casual Japanese
 - A vocab word can stand alone if it captures the right feeling
 - Skip vocabulary entirely if forcing a word would sound unnatural
+- NEVER use dismissive or negative words when the user shares emotional, nostalgic, or significant moments. When in doubt, skip vocabulary.
 
 IMPORTANT:
 - Do NOT mechanically attach particles to vocabulary words. Repeating "word + だな/じゃん/よな" every time sounds robotic.
@@ -472,12 +473,38 @@ How to use vocabulary:
 - You can adapt, riff on, or embed words naturally in slang
 - A vocab word can stand alone if it captures the right feeling
 - Skip vocabulary entirely if forcing a word would sound unnatural
+- NEVER use dismissive or negative words when the user shares emotional, nostalgic, or significant moments. When in doubt, skip vocabulary.
 
 IMPORTANT:
 - Do NOT mechanically slot words into "so [word]" / "not [word]" / "[word]!" patterns every time.
 - React like a real person would. If it sounds forced, skip the vocab.
 - Keep reactions SHORT (1-5 words). No full sentences or explanations.
 - Only skip vocabulary if the entry is so mundane that "word" or "·" is enough.`;
+}
+
+/**
+ * Build sentiment hint labels for vocabulary words that have sentiment data.
+ * Groups words by sentiment and displays them as concise labels.
+ */
+export function buildSentimentHints(words: VocabularyWord[]): string[] {
+  const groups = new Map<string, string[]>();
+  for (const w of words) {
+    if (!w.sentiment) continue;
+    const key = capitalize(w.sentiment);
+    const group = groups.get(key);
+    if (group) {
+      group.push(w.word);
+    } else {
+      groups.set(key, [w.word]);
+    }
+  }
+  if (groups.size === 0) return [];
+
+  const lines: string[] = [];
+  for (const [sentiment, wordList] of groups) {
+    lines.push(`${sentiment}-toned: ${wordList.join(', ')}`);
+  }
+  return lines;
 }
 
 function buildVocabularyPrioritySection(
@@ -495,6 +522,11 @@ function buildVocabularyPrioritySection(
   const parts: string[] = [header];
 
   parts.push(...buildVocabWordList(sampledWords));
+
+  const sentimentHints = buildSentimentHints(sampledWords);
+  if (sentimentHints.length > 0) {
+    parts.push(...sentimentHints);
+  }
 
   if (phrases.length > 0) {
     parts.push(`Phrases: ${phrases.join(', ')}`);
@@ -581,6 +613,7 @@ function buildMoodMappingSection(language?: DetectedLanguage): string {
 - Shocking / unexpected -> Surprise (まじか)
 - Relatable / empathy -> Feeling it (それな)
 - Tough situation / sympathy -> Sympathy (あるある)
+- Nostalgic / remembering / emotional memory -> Nostalgia (なつかし)
 - Simple acknowledgment -> Acknowledgment (うん)`;
   }
 
@@ -592,6 +625,7 @@ function buildMoodMappingSection(language?: DetectedLanguage): string {
 - Shocking / unexpected -> Surprise (no way)
 - Relatable / empathy -> Feeling it (mood)
 - Tough situation / sympathy -> Sympathy (rough)
+- Nostalgic / remembering / emotional memory -> Nostalgia (takes me back)
 - Simple acknowledgment -> Acknowledgment (bet)`;
 }
 

--- a/src/services/wordgrain/types.ts
+++ b/src/services/wordgrain/types.ts
@@ -21,12 +21,16 @@ export interface Grain {
   tags?: string[];
   pos?: GrainPos;
   frequency?: number;
+  sentiment?: string;
+  sentiment_score?: number;
 }
 
 export interface VocabularyWord {
   word: string;
   pos?: GrainPos;
   frequency?: number;
+  sentiment?: string;
+  sentimentScore?: number;
 }
 
 export interface BarSource {

--- a/src/services/wordgrain/vocabulary-extractor.test.ts
+++ b/src/services/wordgrain/vocabulary-extractor.test.ts
@@ -259,6 +259,35 @@ describe('extractVocabulary', () => {
     expect(result.bars[0]?.source?.track).toBe('Track A');
   });
 
+  it('should preserve sentiment in richWords from grain data', () => {
+    const files: WordgrainFile[] = [
+      {
+        name: 'test',
+        grains: [
+          { word: 'chill', sentiment: 'positive', sentiment_score: 0.8 },
+          { word: 'annoying', sentiment: 'negative', sentiment_score: -1.0 },
+          { word: 'plain' },
+        ],
+        bars: [],
+      },
+    ];
+
+    const result = extractVocabulary(files);
+
+    expect(result.richWords).toHaveLength(3);
+    const annoying = result.richWords.find((w) => w.word === 'annoying');
+    expect(annoying?.sentiment).toBe('negative');
+    expect(annoying?.sentimentScore).toBe(-1.0);
+
+    const chill = result.richWords.find((w) => w.word === 'chill');
+    expect(chill?.sentiment).toBe('positive');
+    expect(chill?.sentimentScore).toBe(0.8);
+
+    const plain = result.richWords.find((w) => w.word === 'plain');
+    expect(plain?.sentiment).toBeUndefined();
+    expect(plain?.sentimentScore).toBeUndefined();
+  });
+
   it('should skip bars with empty text', () => {
     const files: WordgrainFile[] = [
       {

--- a/src/services/wordgrain/vocabulary-extractor.ts
+++ b/src/services/wordgrain/vocabulary-extractor.ts
@@ -13,6 +13,8 @@ import type {
 interface WordMeta {
   pos?: GrainPos;
   frequency?: number;
+  sentiment?: string;
+  sentimentScore?: number;
 }
 
 function processGrain(
@@ -38,10 +40,18 @@ function processGrain(
       if (grain.frequency !== undefined) {
         existing.frequency = Math.max(existing.frequency ?? 0, grain.frequency);
       }
+      if (grain.sentiment && !existing.sentiment) {
+        existing.sentiment = grain.sentiment;
+      }
+      if (grain.sentiment_score !== undefined && existing.sentimentScore === undefined) {
+        existing.sentimentScore = grain.sentiment_score;
+      }
     } else {
       wordMetaMap.set(trimmed, {
         pos: grain.pos,
         frequency: grain.frequency,
+        sentiment: grain.sentiment,
+        sentimentScore: grain.sentiment_score,
       });
     }
   }
@@ -65,6 +75,8 @@ function buildRichWords(
     const entry: VocabularyWord = { word };
     if (meta?.pos) entry.pos = meta.pos;
     if (meta?.frequency !== undefined) entry.frequency = meta.frequency;
+    if (meta?.sentiment) entry.sentiment = meta.sentiment;
+    if (meta?.sentimentScore !== undefined) entry.sentimentScore = meta.sentimentScore;
     return entry;
   });
 }

--- a/src/services/wordgrain/wordgrain-loader.test.ts
+++ b/src/services/wordgrain/wordgrain-loader.test.ts
@@ -254,6 +254,87 @@ describe('parseWordgrainFile', () => {
     expect(result?.grains[0]?.frequency).toBe(0);
   });
 
+  it('should parse grains with valid sentiment fields', () => {
+    const filePath = path.join(tmpDir, 'sentiment.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'chill', sentiment: 'positive', sentiment_score: 0.8 },
+          { word: 'annoying', sentiment: 'negative', sentiment_score: -1.0 },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(2);
+    expect(result?.grains[0]?.sentiment).toBe('positive');
+    expect(result?.grains[0]?.sentiment_score).toBe(0.8);
+    expect(result?.grains[1]?.sentiment).toBe('negative');
+    expect(result?.grains[1]?.sentiment_score).toBe(-1.0);
+  });
+
+  it('should accept grains without sentiment fields', () => {
+    const filePath = path.join(tmpDir, 'no-sentiment.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [{ word: 'plain' }],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.sentiment).toBeUndefined();
+    expect(result?.grains[0]?.sentiment_score).toBeUndefined();
+  });
+
+  it('should reject grains with non-string sentiment', () => {
+    const filePath = path.join(tmpDir, 'bad-sentiment.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', sentiment: 'positive' },
+          { word: 'invalid', sentiment: 123 },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
+  it('should reject grains with non-number sentiment_score', () => {
+    const filePath = path.join(tmpDir, 'bad-score.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', sentiment_score: 0.5 },
+          { word: 'invalid', sentiment_score: 'high' },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
   it('should parse v0.2.0 bar-type files', () => {
     const filePath = path.join(tmpDir, 'bar.wg.json');
     fs.writeFileSync(

--- a/src/services/wordgrain/wordgrain-loader.ts
+++ b/src/services/wordgrain/wordgrain-loader.ts
@@ -52,6 +52,9 @@ function isValidGrain(obj: unknown): obj is Grain {
   if (record['frequency'] !== undefined) {
     if (typeof record['frequency'] !== 'number' || record['frequency'] < 0) return false;
   }
+  if (record['sentiment'] !== undefined && typeof record['sentiment'] !== 'string') return false;
+  if (record['sentiment_score'] !== undefined && typeof record['sentiment_score'] !== 'number')
+    return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary

Fixes vocabulary sentiment mismatch where negative-toned words like "めんどくさい" could be used as reactions to emotional/nostalgic entries. Adds sentiment awareness throughout the vocabulary pipeline so the LLM knows which words are negative-toned and avoids using them inappropriately.

- Add sentiment fields to Grain/VocabularyWord types and validate in loader
- Carry sentiment through extraction pipeline into prompts
- Add sentiment hint labels (e.g. "Negative-toned: めんどくさい") to vocabulary section
- Add sentiment-matching rule: "NEVER use dismissive or negative words for emotional/nostalgic moments"
- Add nostalgia mood category to mood mapping (JA/EN)

## Changes

- **src/services/wordgrain/types.ts**: Add `sentiment`/`sentiment_score` to `Grain`, `sentiment`/`sentimentScore` to `VocabularyWord`
- **src/services/wordgrain/wordgrain-loader.ts**: Validate sentiment fields in `isValidGrain()`
- **src/services/wordgrain/vocabulary-extractor.ts**: Carry sentiment through `WordMeta`, `processGrain()`, `buildRichWords()`
- **src/services/llm/prompts.ts**: Add `buildSentimentHints()`, sentiment-matching rule, nostalgia mood category
- **Test files**: Comprehensive tests for all changes

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm ci:check` (Biome lint) passes
- [x] All 810 tests pass with coverage thresholds met
- [ ] Manual: verify prompt output includes sentiment hints and nostalgia mood for vocabulary with sentiment data