### PR TITLE
Add Japanese tokenization using Intl.Segmenter

### DIFF
--- a/src/services/llm/bar-selector.test.ts
+++ b/src/services/llm/bar-selector.test.ts
@@ -181,4 +181,35 @@ describe('selectBarsForReaction', () => {
     const result = selectBarsForReaction(bars, 'hustle grind', 5, 3);
     expect(result.length).toBeLessThanOrEqual(5);
   });
+
+  it('should match Japanese bars with Japanese entry text', () => {
+    const bars: Bar[] = [
+      { text: '仕事は大変だけど頑張ろう', language: 'ja' },
+      { text: '天気がいい日は散歩しよう', language: 'ja' },
+      { text: 'sunshine rainbow', language: 'en' },
+      { text: 'random filler one', language: 'en' },
+      { text: 'random filler two', language: 'en' },
+      { text: 'random filler three', language: 'en' },
+      { text: 'random filler four', language: 'en' },
+      { text: 'random filler five', language: 'en' },
+    ];
+    let matchCount = 0;
+    const runs = 20;
+    for (let i = 0; i < runs; i++) {
+      const result = selectBarsForReaction(bars, '仕事がつらい', 5, 3, 'ja');
+      for (const r of result) {
+        if (r.text === '仕事は大変だけど頑張ろう') matchCount++;
+      }
+    }
+    // The Japanese bar with "仕事" overlap should appear frequently
+    expect(matchCount / runs).toBeGreaterThan(0.5);
+  });
+});
+
+describe('buildEntryTokens - Japanese', () => {
+  it('should tokenize Japanese entry text into meaningful tokens', () => {
+    const tokens = buildEntryTokens('仕事がつらい');
+    expect(tokens.has('仕事')).toBe(true);
+    expect(tokens.has('つらい')).toBe(true);
+  });
 });

--- a/src/services/llm/bar-selector.ts
+++ b/src/services/llm/bar-selector.ts
@@ -5,26 +5,16 @@
  * then selects a mix of relevant + random bars.
  */
 
+import { tokenize } from '../../utils/tokenize.js';
 import type { DetectedLanguage } from '../language/types.js';
 import { isStopWord } from '../trends/stopwords.js';
 import type { Bar } from '../wordgrain/types.js';
 
-const MIN_TOKEN_LENGTH = 2;
-
 /**
- * Normalize text for token matching (duplicated from topic-extractor to avoid coupling)
+ * Normalize text for token matching
  */
 function normalizeText(text: string): string {
   return text.toLowerCase().trim();
-}
-
-/**
- * Split text into tokens (duplicated from topic-extractor to avoid coupling)
- */
-function tokenize(text: string): string[] {
-  return text
-    .split(/[\s,.!?;:'"()\[\]{}\-_/\\|@#$%^&*+=<>~`]+/)
-    .filter((token) => token.length >= MIN_TOKEN_LENGTH);
 }
 
 /**

--- a/src/services/trends/topic-extractor.test.ts
+++ b/src/services/trends/topic-extractor.test.ts
@@ -84,4 +84,18 @@ describe('extractTopics', () => {
     const topics = extractTopics('email@work.com project-update #deadline');
     expect(topics.length).toBeGreaterThan(0);
   });
+
+  it('should extract topics from Japanese text', () => {
+    const topics = extractTopics('仕事がつらい');
+    expect(topics.length).toBeGreaterThan(0);
+    expect(topics).toContain('仕事');
+    expect(topics).toContain('つらい');
+  });
+
+  it('should extract topics from longer Japanese sentences', () => {
+    const topics = extractTopics('今日は天気がいいので散歩した');
+    expect(topics.length).toBeGreaterThan(0);
+    expect(topics).toContain('今日');
+    expect(topics).toContain('天気');
+  });
 });

--- a/src/services/trends/topic-extractor.ts
+++ b/src/services/trends/topic-extractor.ts
@@ -3,6 +3,7 @@
  * Simple text processing without NLP libraries
  */
 
+import { tokenize } from '../../utils/tokenize.js';
 import { isStopWord } from './stopwords.js';
 
 const MIN_WORD_LENGTH = 2;
@@ -13,16 +14,6 @@ const MAX_TOPICS = 10;
  */
 function normalizeText(text: string): string {
   return text.toLowerCase().trim();
-}
-
-/**
- * Split text into tokens (handles both English and Japanese)
- */
-function tokenize(text: string): string[] {
-  // Split on whitespace and common punctuation
-  return text
-    .split(/[\s,.!?;:'"()\[\]{}\-_/\\|@#$%^&*+=<>~`]+/)
-    .filter((token) => token.length >= MIN_WORD_LENGTH);
 }
 
 /**

--- a/src/utils/tokenize.test.ts
+++ b/src/utils/tokenize.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { tokenize } from './tokenize.js';
+
+describe('tokenize', () => {
+  describe('English text', () => {
+    it('should split on whitespace and punctuation', () => {
+      const tokens = tokenize('coffee, sleep, repeat!');
+      expect(tokens).toContain('coffee');
+      expect(tokens).toContain('sleep');
+      expect(tokens).toContain('repeat');
+    });
+
+    it('should filter out short tokens', () => {
+      const tokens = tokenize('I a x coffee');
+      expect(tokens).not.toContain('I');
+      expect(tokens).not.toContain('a');
+      expect(tokens).not.toContain('x');
+      expect(tokens).toContain('coffee');
+    });
+
+    it('should handle special characters', () => {
+      const tokens = tokenize('email@work.com project-update #deadline');
+      expect(tokens).toContain('email');
+      expect(tokens).toContain('work');
+      expect(tokens).toContain('project');
+      expect(tokens).toContain('update');
+      expect(tokens).toContain('deadline');
+    });
+  });
+
+  describe('Japanese text', () => {
+    it('should segment Japanese text into words', () => {
+      const tokens = tokenize('仕事がつらい');
+      expect(tokens).toContain('仕事');
+      expect(tokens).toContain('つらい');
+    });
+
+    it('should filter out single-character particles', () => {
+      const tokens = tokenize('仕事がつらい');
+      // Single-char particle "が" should be filtered by MIN_TOKEN_LENGTH
+      expect(tokens).not.toContain('が');
+    });
+
+    it('should handle longer Japanese sentences', () => {
+      const tokens = tokenize('今日は天気がいい');
+      expect(tokens.length).toBeGreaterThan(0);
+      expect(tokens).toContain('今日');
+      expect(tokens).toContain('天気');
+    });
+
+    it('should handle katakana words', () => {
+      const tokens = tokenize('コーヒーを飲んだ');
+      expect(tokens).toContain('コーヒー');
+    });
+  });
+
+  describe('mixed text', () => {
+    it('should handle mixed Japanese and English text', () => {
+      // Text with >10% CJK will use Japanese segmentation
+      const tokens = tokenize('今日のミーティングはproject関連');
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty array for empty string', () => {
+      expect(tokenize('')).toEqual([]);
+    });
+
+    it('should return empty array for whitespace only', () => {
+      expect(tokenize('   ')).toEqual([]);
+    });
+
+    it('should return empty array for only punctuation', () => {
+      expect(tokenize('.,!?')).toEqual([]);
+    });
+  });
+});

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared tokenization utility with language-aware segmentation.
+ * Uses Intl.Segmenter for Japanese text, regex splitting for English.
+ */
+
+import { detectLanguage } from '../services/language/detect.js';
+
+const MIN_TOKEN_LENGTH = 2;
+const PUNCTUATION_SPLIT = /[\s,.!?;:'"()\[\]{}\-_/\\|@#$%^&*+=<>~`]+/;
+
+function tokenizeEnglish(text: string): string[] {
+  return text.split(PUNCTUATION_SPLIT).filter((token) => token.length >= MIN_TOKEN_LENGTH);
+}
+
+function tokenizeJapanese(text: string): string[] {
+  const segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
+  return [...segmenter.segment(text)]
+    .filter((s) => s.isWordLike)
+    .map((s) => s.segment)
+    .filter((token) => token.length >= MIN_TOKEN_LENGTH);
+}
+
+export function tokenize(text: string): string[] {
+  const language = detectLanguage(text);
+  if (language === 'ja') {
+    return tokenizeJapanese(text);
+  }
+  return tokenizeEnglish(text);
+}


### PR DESCRIPTION
## Summary

Implements issue #190 by adding language-aware tokenization using `Intl.Segmenter` for Japanese text. This fixes Japanese entries producing few/no topics and Japanese bars never matching entry keywords.

- Create shared `tokenize` utility in `src/utils/tokenize.ts`
- Replace duplicated local `tokenize` functions in `topic-extractor.ts` and `bar-selector.ts`
- Add comprehensive tests for Japanese segmentation

## Changes

- **src/utils/tokenize.ts**: New shared tokenize utility that uses `detectLanguage` to choose between `Intl.Segmenter` (Japanese) and regex splitting (English)
- **src/utils/tokenize.test.ts**: Unit tests covering English, Japanese, mixed text, and edge cases
- **src/services/trends/topic-extractor.ts**: Replace local tokenize with shared import
- **src/services/llm/bar-selector.ts**: Replace local tokenize with shared import
- **src/services/trends/topic-extractor.test.ts**: Add Japanese topic extraction tests
- **src/services/llm/bar-selector.test.ts**: Add Japanese bar matching tests

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm check` passes (lint + format)
- [x] All 812 tests pass (54 test files)
- [x] `tokenize("仕事がつらい")` returns `["仕事", "つらい"]`
- [x] `extractTopics("仕事がつらい")` returns topics including "仕事" and "つらい"
- [x] Japanese bars match Japanese entry keywords in bar-selector
- [x] English tokenization behavior unchanged (backward compatible)