### PR TITLE
Fix initial Write mode and splash screen not using full terminal height (#195)

### DIFF
--- a/src/ui/components/splash/SplashScreen.tsx
+++ b/src/ui/components/splash/SplashScreen.tsx
@@ -1,5 +1,6 @@
 import { Box } from 'ink';
 import React, { useEffect, useState } from 'react';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { LoadingAnimation } from './LoadingAnimation.js';
 import { Logo } from './Logo.js';
 
@@ -9,6 +10,7 @@ interface SplashScreenProps {
 }
 
 export function SplashScreen({ onComplete, duration = 2500 }: SplashScreenProps) {
+  const { rows: terminalRows } = useTerminalSize();
   const [showLoading, setShowLoading] = useState(false);
 
   useEffect(() => {
@@ -27,7 +29,7 @@ export function SplashScreen({ onComplete, duration = 2500 }: SplashScreenProps)
   }, [onComplete, duration]);
 
   return (
-    <Box flexDirection="column" alignItems="center" padding={1}>
+    <Box flexDirection="column" alignItems="center" padding={1} height={terminalRows}>
       <Logo />
       <Box marginTop={1}>{showLoading && <LoadingAnimation />}</Box>
     </Box>

--- a/src/ui/components/write/WriteView.tsx
+++ b/src/ui/components/write/WriteView.tsx
@@ -2,10 +2,22 @@ import { Box, Text, useInput } from 'ink';
 import React from 'react';
 import { useNavigation } from '../../context/NavigationContext.js';
 import { useServices } from '../../context/ServiceContext.js';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 
 export function WriteView() {
   const { switchToList, writeState, setWriteState } = useNavigation();
   const { entryService } = useServices();
+  const { rows: terminalRows } = useTerminalSize();
+
+  // Calculate text input height: terminal rows minus all non-input UI lines.
+  // Overhead (17 lines):
+  //   App header:  padding-top(1) + content(1) + padding-bottom(1) + marginBottom(1) = 4
+  //   WriteView:   padding-top(1) + "New Entry" title(1) + marginBottom(1) + padding-bottom(1) = 4
+  //   Text input:  borderTop(1) + padding-top(1) + padding-bottom(1) + borderBottom(1) = 4
+  //   Char count:  marginTop(1) + content(1) = 2
+  //   Footer:      marginTop(1) + content(1) = 2
+  //   Buffer:      1
+  const textInputHeight = Math.max(3, terminalRows - 17);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -46,7 +58,13 @@ export function WriteView() {
         </Text>
       </Box>
 
-      <Box borderStyle="round" borderColor="green" padding={1} flexDirection="column" minHeight={5}>
+      <Box
+        borderStyle="round"
+        borderColor="green"
+        padding={1}
+        flexDirection="column"
+        height={textInputHeight}
+      >
         <Text>{writeState.content || <Text dimColor>Start typing...</Text>}</Text>
       </Box>
 


### PR DESCRIPTION
## Summary

Fixes issue #195 by adding explicit terminal height to WriteView and SplashScreen, matching the pattern already used by EntryList.

- Add `useTerminalSize()` to WriteView for explicit text input height
- Add `useTerminalSize()` to SplashScreen for full-terminal rendering
- Ink's `flexGrow` doesn't reliably fill vertical space on first render

## Changes

- **src/ui/components/write/WriteView.tsx**: Import `useTerminalSize()` hook, calculate explicit `height` for the text input box based on terminal rows minus UI overhead (17 lines), replacing `minHeight={5}` that relied on `flexGrow`
- **src/ui/components/splash/SplashScreen.tsx**: Import `useTerminalSize()` hook, set explicit `height={terminalRows}` on the outer Box to fill the terminal on first render

## Test plan

- [ ] Launch app (`pnpm dev`) and confirm splash screen fills the terminal
- [ ] Confirm initial Write mode fills the terminal vertically
- [ ] Switch to List mode (Tab) and back to Write mode — confirm no regression
- [ ] Resize terminal window — confirm Write mode adjusts height
- [ ] `pnpm type-check && pnpm lint && pnpm test:coverage` all pass

Resolves #195
