### PR TITLE
Add delete entry feature from detail view

### DIFF
--- a/src/ui/components/common/HelpFooter.tsx
+++ b/src/ui/components/common/HelpFooter.tsx
@@ -19,7 +19,7 @@ export function HelpFooter({ mode, isViewingDetail = false, queueStatus }: HelpF
       return 'j/k: navigate | a: add | d: unregister | r: reload | Esc: back | q: quit';
     }
     if (isViewingDetail) {
-      return 'Esc/q: back | Tab: write';
+      return 'Esc/q: back | d: delete | Tab: write';
     }
     return 'j/k: navigate | Enter: view | Tab: write | c: config | q: quit';
   };

--- a/src/ui/components/entries/EntryDetail.tsx
+++ b/src/ui/components/entries/EntryDetail.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput } from 'ink';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { JournalEntry } from '../../../repositories/types.js';
+import { useServices } from '../../context/ServiceContext.js';
 import { useReactions } from '../../hooks/useReactions.js';
 import { formatFullDate } from '../../utils/date-formatter.js';
 import { formatReactionDisplay } from './EntryListItem.js';
@@ -8,10 +9,32 @@ import { formatReactionDisplay } from './EntryListItem.js';
 interface EntryDetailProps {
   entry: JournalEntry;
   onClose: () => void;
+  onDelete?: () => void;
 }
 
-export function EntryDetail({ entry, onClose }: EntryDetailProps) {
+export function EntryDetail({ entry, onClose, onDelete }: EntryDetailProps) {
+  const { entryService } = useServices();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
   useInput((input, key) => {
+    if (confirmingDelete) {
+      if (input === 'y') {
+        entryService.delete(entry.id);
+        onDelete?.();
+        return;
+      }
+      if (input === 'n' || key.escape) {
+        setConfirmingDelete(false);
+        return;
+      }
+      return;
+    }
+
+    if (input === 'd') {
+      setConfirmingDelete(true);
+      return;
+    }
+
     if (key.escape || input === 'q') {
       onClose();
     }
@@ -80,9 +103,20 @@ export function EntryDetail({ entry, onClose }: EntryDetailProps) {
         )}
       </Box>
 
-      <Box marginTop={1} justifyContent="center">
-        <Text dimColor>Press Escape or 'q' to close</Text>
-      </Box>
+      {confirmingDelete ? (
+        <Box marginTop={1} flexDirection="column" alignItems="center">
+          <Text bold color="red">
+            Delete this entry?
+          </Text>
+          <Box marginTop={1}>
+            <Text dimColor>y: confirm | n/Esc: cancel</Text>
+          </Box>
+        </Box>
+      ) : (
+        <Box marginTop={1} justifyContent="center">
+          <Text dimColor>Esc/q: back | d: delete</Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/components/entries/EntryList.tsx
+++ b/src/ui/components/entries/EntryList.tsx
@@ -33,7 +33,7 @@ interface EntryListProps {
 }
 
 export function EntryList({ onViewingDetailChange }: EntryListProps) {
-  const { entries, loading, error } = useEntries();
+  const { entries, loading, error, refetch } = useEntries();
   const { listState, setListState } = useNavigation();
   const [viewingEntry, setViewingEntry] = useState<JournalEntry | null>(null);
 
@@ -181,7 +181,16 @@ export function EntryList({ onViewingDetailChange }: EntryListProps) {
   }
 
   if (viewingEntry) {
-    return <EntryDetail entry={viewingEntry} onClose={() => setViewingEntry(null)} />;
+    return (
+      <EntryDetail
+        entry={viewingEntry}
+        onClose={() => setViewingEntry(null)}
+        onDelete={() => {
+          setViewingEntry(null);
+          refetch();
+        }}
+      />
+    );
   }
 
   if (entries.length === 0) {


### PR DESCRIPTION
## Summary

Implements issue #197 by adding the ability to delete an entry from the post detail page.

- Press `d` on the detail view to trigger delete confirmation
- Confirmation prompt (`y`/`n`) prevents accidental deletion
- After deletion, returns to entry list with refreshed data

## Changes

- **EntryDetail.tsx**: Add delete confirmation state and keyboard handling (`d` to trigger, `y` to confirm, `n`/`Esc` to cancel), display confirmation prompt in red
- **EntryList.tsx**: Pass `onDelete` callback to EntryDetail that clears the viewing state and refetches entries
- **HelpFooter.tsx**: Add `d: delete` shortcut hint in detail view

## Test plan

- [ ] Open entry detail view, press `d`, verify confirmation prompt appears
- [ ] Press `n` or `Esc` during confirmation, verify it cancels and returns to normal detail view
- [ ] Press `y` during confirmation, verify entry is deleted and list view is shown without the deleted entry
- [ ] Verify cascading deletes work (reactions, topics, etc. are cleaned up by database)