### PR TITLE
Leverage wordgrain tfidf, categories, collocations, is_slang for richer reactions

### DIFF
--- a/src/services/llm/prompts.test.ts
+++ b/src/services/llm/prompts.test.ts
@@ -3,7 +3,10 @@ import type { VocabularySet, VocabularyWord } from '../wordgrain/types.js';
 import {
   MUMBL_SYSTEM_PROMPT,
   buildBarReferenceSection,
+  buildCategoryHints,
+  buildCollocationHints,
   buildSentimentHints,
+  buildSlangHints,
   createCalloutPrompt,
   createChatMessages,
   createFollowUpEvaluationPrompt,
@@ -1179,6 +1182,173 @@ describe('sentiment-matching rule in vocabulary usage', () => {
 
     expect(systemContent).toContain('Negative-toned: annoying');
     expect(systemContent).toContain('Positive-toned: great');
+  });
+});
+
+describe('weightedSample with tfidf', () => {
+  it('should give higher weight to words with tfidf', () => {
+    const items: VocabularyWord[] = [
+      { word: 'common', frequency: 10, tfidf: 0 },
+      { word: 'distinctive', frequency: 10, tfidf: 1.0 },
+    ];
+
+    const counts: Record<string, number> = { common: 0, distinctive: 0 };
+    for (let i = 0; i < 1000; i++) {
+      const result = weightedSample(items, 1);
+      const word = result[0]?.word ?? '';
+      counts[word] = (counts[word] ?? 0) + 1;
+    }
+
+    expect(counts['distinctive']).toBeGreaterThan(counts['common'] ?? 0);
+  });
+
+  it('should not break when tfidf is undefined', () => {
+    const items: VocabularyWord[] = [
+      { word: 'a', frequency: 5 },
+      { word: 'b', frequency: 5 },
+    ];
+    const result = weightedSample(items, 1);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('buildCollocationHints', () => {
+  it('should build hints for words with collocations', () => {
+    const words: VocabularyWord[] = [
+      { word: 'drip', collocations: ['ice', 'flex', 'sauce'] },
+      { word: 'plain' },
+    ];
+    const hints = buildCollocationHints(words);
+
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toBe('"drip" pairs with: ice, flex, sauce');
+  });
+
+  it('should return empty array when no words have collocations', () => {
+    const words: VocabularyWord[] = [{ word: 'plain' }, { word: 'basic' }];
+    const hints = buildCollocationHints(words);
+
+    expect(hints).toEqual([]);
+  });
+});
+
+describe('buildCategoryHints', () => {
+  it('should group words by category and show top 3', () => {
+    const words: VocabularyWord[] = [
+      { word: 'drip', categories: ['style', 'fashion'] },
+      { word: 'flex', categories: ['style', 'money'] },
+      { word: 'chill', categories: ['emotion'] },
+      { word: 'hype', categories: ['emotion'] },
+      { word: 'rare', categories: ['unique'] },
+    ];
+    const hints = buildCategoryHints(words);
+
+    expect(hints).toHaveLength(3);
+    expect(hints[0]).toBe('Category "style": drip, flex');
+    expect(hints[1]).toBe('Category "emotion": chill, hype');
+  });
+
+  it('should return empty array when no words have categories', () => {
+    const words: VocabularyWord[] = [{ word: 'plain' }];
+    const hints = buildCategoryHints(words);
+
+    expect(hints).toEqual([]);
+  });
+});
+
+describe('buildSlangHints', () => {
+  it('should list slang words', () => {
+    const words: VocabularyWord[] = [
+      { word: 'drip', isSlang: true },
+      { word: 'cap', isSlang: true },
+      { word: 'normal' },
+    ];
+    const hints = buildSlangHints(words);
+
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toBe('Slang/casual: drip, cap');
+  });
+
+  it('should return empty array when no slang words', () => {
+    const words: VocabularyWord[] = [{ word: 'plain' }];
+    const hints = buildSlangHints(words);
+
+    expect(hints).toEqual([]);
+  });
+});
+
+describe('sentiment behavioral rule in prompt', () => {
+  it('should include tone-matching instruction when sentiment data present', () => {
+    const vocab: VocabularySet = {
+      words: ['chill', 'annoying'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [
+        { word: 'chill', sentiment: 'positive' },
+        { word: 'annoying', sentiment: 'negative' },
+      ],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain(
+      'Match vocabulary tone to entry mood: positive words for upbeat entries, negative for tough ones, any for neutral.',
+    );
+  });
+});
+
+describe('collocation, category, and slang hints in prompt', () => {
+  it('should include collocation hints in reaction prompt', () => {
+    const vocab: VocabularySet = {
+      words: ['drip'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [{ word: 'drip', collocations: ['ice', 'flex'] }],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('"drip" pairs with: ice, flex');
+  });
+
+  it('should include category hints in reaction prompt', () => {
+    const vocab: VocabularySet = {
+      words: ['drip', 'flex'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [
+        { word: 'drip', categories: ['style'] },
+        { word: 'flex', categories: ['style'] },
+      ],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Category "style": drip, flex');
+  });
+
+  it('should include slang hints in reaction prompt', () => {
+    const vocab: VocabularySet = {
+      words: ['drip', 'cap'],
+      phrases: [],
+      tags: [],
+      source: 'test',
+      richWords: [
+        { word: 'drip', isSlang: true },
+        { word: 'cap', isSlang: true },
+      ],
+      bars: [],
+    };
+    const messages = createReactionPrompt('test', { language: 'en' }, vocab);
+    const systemContent = messages[0]?.content ?? '';
+
+    expect(systemContent).toContain('Slang/casual: drip, cap');
   });
 });
 

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -320,7 +320,9 @@ export function weightedSample(items: VocabularyWord[], count: number): Vocabula
   const remaining = [...items];
 
   for (let picked = 0; picked < count && remaining.length > 0; picked++) {
-    const weights = remaining.map((item) => Math.sqrt((item.frequency ?? 0) + 1));
+    const weights = remaining.map(
+      (item) => Math.sqrt((item.frequency ?? 0) + 1) * (1 + (item.tfidf ?? 0)),
+    );
     const totalWeight = weights.reduce((sum, w) => sum + w, 0);
 
     let random = Math.random() * totalWeight;
@@ -546,6 +548,53 @@ export function buildSentimentHints(words: VocabularyWord[]): string[] {
   return lines;
 }
 
+/**
+ * Build collocation hints for sampled vocabulary words.
+ * Shows the LLM which words naturally pair together.
+ */
+export function buildCollocationHints(words: VocabularyWord[]): string[] {
+  const lines: string[] = [];
+  for (const w of words) {
+    if (w.collocations && w.collocations.length > 0) {
+      lines.push(`"${w.word}" pairs with: ${w.collocations.join(', ')}`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Build category grouping hints for sampled vocabulary words.
+ * Groups words by category and shows top 3 categories.
+ */
+export function buildCategoryHints(words: VocabularyWord[]): string[] {
+  const groups = new Map<string, string[]>();
+  for (const w of words) {
+    if (!w.categories) continue;
+    for (const cat of w.categories) {
+      const group = groups.get(cat);
+      if (group) {
+        group.push(w.word);
+      } else {
+        groups.set(cat, [w.word]);
+      }
+    }
+  }
+  if (groups.size === 0) return [];
+
+  const sorted = [...groups.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 3);
+  return sorted.map(([cat, wordList]) => `Category "${cat}": ${wordList.join(', ')}`);
+}
+
+/**
+ * Build slang hints for sampled vocabulary words.
+ * Flags which words are slang/casual for appropriate usage.
+ */
+export function buildSlangHints(words: VocabularyWord[]): string[] {
+  const slangWords = words.filter((w) => w.isSlang === true).map((w) => w.word);
+  if (slangWords.length === 0) return [];
+  return [`Slang/casual: ${slangWords.join(', ')}`];
+}
+
 function buildVocabularyPrioritySection(
   vocabulary: VocabularySet,
   language?: DetectedLanguage,
@@ -565,6 +614,24 @@ function buildVocabularyPrioritySection(
   const sentimentHints = buildSentimentHints(sampledWords);
   if (sentimentHints.length > 0) {
     parts.push(...sentimentHints);
+    parts.push(
+      'Match vocabulary tone to entry mood: positive words for upbeat entries, negative for tough ones, any for neutral.',
+    );
+  }
+
+  const collocationHints = buildCollocationHints(sampledWords);
+  if (collocationHints.length > 0) {
+    parts.push(...collocationHints);
+  }
+
+  const categoryHints = buildCategoryHints(sampledWords);
+  if (categoryHints.length > 0) {
+    parts.push(...categoryHints);
+  }
+
+  const slangHints = buildSlangHints(sampledWords);
+  if (slangHints.length > 0) {
+    parts.push(...slangHints);
   }
 
   if (phrases.length > 0) {

--- a/src/services/wordgrain/types.ts
+++ b/src/services/wordgrain/types.ts
@@ -23,6 +23,11 @@ export interface Grain {
   frequency?: number;
   sentiment?: string;
   sentiment_score?: number;
+  tfidf?: number;
+  categories?: string[];
+  collocations?: string[];
+  is_slang?: boolean;
+  definition?: string;
 }
 
 export interface VocabularyWord {
@@ -31,6 +36,10 @@ export interface VocabularyWord {
   frequency?: number;
   sentiment?: string;
   sentimentScore?: number;
+  tfidf?: number;
+  collocations?: string[];
+  categories?: string[];
+  isSlang?: boolean;
 }
 
 export interface BarSource {

--- a/src/services/wordgrain/vocabulary-extractor.test.ts
+++ b/src/services/wordgrain/vocabulary-extractor.test.ts
@@ -288,6 +288,97 @@ describe('extractVocabulary', () => {
     expect(plain?.sentimentScore).toBeUndefined();
   });
 
+  it('should extract tfidf, collocations, categories, and isSlang into richWords', () => {
+    const files: WordgrainFile[] = [
+      {
+        name: 'test',
+        grains: [
+          {
+            word: 'drip',
+            tfidf: 0.85,
+            categories: ['style', 'fashion'],
+            collocations: ['ice', 'flex'],
+            is_slang: true,
+          },
+          { word: 'chill' },
+        ],
+        bars: [],
+      },
+    ];
+
+    const result = extractVocabulary(files);
+
+    const drip = result.richWords.find((w) => w.word === 'drip');
+    expect(drip?.tfidf).toBe(0.85);
+    expect(drip?.categories).toEqual(['style', 'fashion']);
+    expect(drip?.collocations).toEqual(['ice', 'flex']);
+    expect(drip?.isSlang).toBe(true);
+
+    const chill = result.richWords.find((w) => w.word === 'chill');
+    expect(chill?.tfidf).toBeUndefined();
+    expect(chill?.categories).toBeUndefined();
+    expect(chill?.collocations).toBeUndefined();
+    expect(chill?.isSlang).toBeUndefined();
+  });
+
+  it('should merge tfidf keeping max value on duplicates', () => {
+    const files: WordgrainFile[] = [
+      {
+        name: 'a',
+        grains: [{ word: 'drip', tfidf: 0.3 }],
+        bars: [],
+      },
+      {
+        name: 'b',
+        grains: [{ word: 'drip', tfidf: 0.8 }],
+        bars: [],
+      },
+    ];
+
+    const result = extractVocabulary(files);
+    const drip = result.richWords.find((w) => w.word === 'drip');
+    expect(drip?.tfidf).toBe(0.8);
+  });
+
+  it('should merge collocations and categories deduplicating on duplicates', () => {
+    const files: WordgrainFile[] = [
+      {
+        name: 'a',
+        grains: [{ word: 'drip', collocations: ['ice', 'flex'], categories: ['style'] }],
+        bars: [],
+      },
+      {
+        name: 'b',
+        grains: [{ word: 'drip', collocations: ['flex', 'sauce'], categories: ['style', 'slang'] }],
+        bars: [],
+      },
+    ];
+
+    const result = extractVocabulary(files);
+    const drip = result.richWords.find((w) => w.word === 'drip');
+    expect(drip?.collocations).toEqual(['ice', 'flex', 'sauce']);
+    expect(drip?.categories).toEqual(['style', 'slang']);
+  });
+
+  it('should OR isSlang across duplicate grains', () => {
+    const files: WordgrainFile[] = [
+      {
+        name: 'a',
+        grains: [{ word: 'drip', is_slang: false }],
+        bars: [],
+      },
+      {
+        name: 'b',
+        grains: [{ word: 'drip', is_slang: true }],
+        bars: [],
+      },
+    ];
+
+    const result = extractVocabulary(files);
+    const drip = result.richWords.find((w) => w.word === 'drip');
+    expect(drip?.isSlang).toBe(true);
+  });
+
   it('should skip bars with empty text', () => {
     const files: WordgrainFile[] = [
       {

--- a/src/services/wordgrain/vocabulary-extractor.ts
+++ b/src/services/wordgrain/vocabulary-extractor.ts
@@ -15,6 +15,10 @@ interface WordMeta {
   frequency?: number;
   sentiment?: string;
   sentimentScore?: number;
+  tfidf?: number;
+  collocations?: string[];
+  categories?: string[];
+  isSlang?: boolean;
 }
 
 function processGrain(
@@ -46,12 +50,32 @@ function processGrain(
       if (grain.sentiment_score !== undefined && existing.sentimentScore === undefined) {
         existing.sentimentScore = grain.sentiment_score;
       }
+      if (grain.tfidf !== undefined) {
+        existing.tfidf = Math.max(existing.tfidf ?? 0, grain.tfidf);
+      }
+      if (grain.collocations) {
+        const merged = new Set(existing.collocations ?? []);
+        for (const c of grain.collocations) merged.add(c);
+        existing.collocations = [...merged];
+      }
+      if (grain.categories) {
+        const merged = new Set(existing.categories ?? []);
+        for (const c of grain.categories) merged.add(c);
+        existing.categories = [...merged];
+      }
+      if (grain.is_slang === true) {
+        existing.isSlang = true;
+      }
     } else {
       wordMetaMap.set(trimmed, {
         pos: grain.pos,
         frequency: grain.frequency,
         sentiment: grain.sentiment,
         sentimentScore: grain.sentiment_score,
+        tfidf: grain.tfidf,
+        collocations: grain.collocations ? [...grain.collocations] : undefined,
+        categories: grain.categories ? [...grain.categories] : undefined,
+        isSlang: grain.is_slang,
       });
     }
   }
@@ -77,6 +101,10 @@ function buildRichWords(
     if (meta?.frequency !== undefined) entry.frequency = meta.frequency;
     if (meta?.sentiment) entry.sentiment = meta.sentiment;
     if (meta?.sentimentScore !== undefined) entry.sentimentScore = meta.sentimentScore;
+    if (meta?.tfidf !== undefined) entry.tfidf = meta.tfidf;
+    if (meta?.collocations && meta.collocations.length > 0) entry.collocations = meta.collocations;
+    if (meta?.categories && meta.categories.length > 0) entry.categories = meta.categories;
+    if (meta?.isSlang === true) entry.isSlang = true;
     return entry;
   });
 }

--- a/src/services/wordgrain/wordgrain-loader.test.ts
+++ b/src/services/wordgrain/wordgrain-loader.test.ts
@@ -458,6 +458,160 @@ describe('parseWordgrainFile', () => {
     expect(result?.bars).toHaveLength(2);
   });
 
+  it('should parse grains with valid tfidf, categories, collocations, is_slang, and definition', () => {
+    const filePath = path.join(tmpDir, 'v020-fields.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          {
+            word: 'drip',
+            tfidf: 0.85,
+            categories: ['style', 'fashion'],
+            collocations: ['ice', 'flex'],
+            is_slang: true,
+            definition: 'stylish appearance',
+          },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.tfidf).toBe(0.85);
+    expect(result?.grains[0]?.categories).toEqual(['style', 'fashion']);
+    expect(result?.grains[0]?.collocations).toEqual(['ice', 'flex']);
+    expect(result?.grains[0]?.is_slang).toBe(true);
+    expect(result?.grains[0]?.definition).toBe('stylish appearance');
+  });
+
+  it('should accept grains without new v0.2.0 fields', () => {
+    const filePath = path.join(tmpDir, 'no-new-fields.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [{ word: 'plain' }],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.tfidf).toBeUndefined();
+    expect(result?.grains[0]?.categories).toBeUndefined();
+    expect(result?.grains[0]?.collocations).toBeUndefined();
+    expect(result?.grains[0]?.is_slang).toBeUndefined();
+    expect(result?.grains[0]?.definition).toBeUndefined();
+  });
+
+  it('should reject grains with negative tfidf', () => {
+    const filePath = path.join(tmpDir, 'bad-tfidf.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', tfidf: 0.5 },
+          { word: 'negative', tfidf: -0.1 },
+          { word: 'not-number', tfidf: 'high' },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
+  it('should reject grains with non-array categories', () => {
+    const filePath = path.join(tmpDir, 'bad-categories.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', categories: ['style'] },
+          { word: 'invalid', categories: 'style' },
+          { word: 'also-invalid', categories: [123] },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
+  it('should reject grains with non-array collocations', () => {
+    const filePath = path.join(tmpDir, 'bad-collocations.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', collocations: ['ice'] },
+          { word: 'invalid', collocations: 'ice' },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
+  it('should reject grains with non-boolean is_slang', () => {
+    const filePath = path.join(tmpDir, 'bad-slang.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', is_slang: true },
+          { word: 'invalid', is_slang: 'yes' },
+          { word: 'also-invalid', is_slang: 1 },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
+  it('should reject grains with non-string definition', () => {
+    const filePath = path.join(tmpDir, 'bad-definition.wg.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        name: 'test',
+        grains: [
+          { word: 'valid', definition: 'a word' },
+          { word: 'invalid', definition: 123 },
+        ],
+      }),
+    );
+
+    const result = parseWordgrainFile(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result?.grains).toHaveLength(1);
+    expect(result?.grains[0]?.word).toBe('valid');
+  });
+
   it('should reject bar entries with non-string text', () => {
     const filePath = path.join(tmpDir, 'bad-bar.wg.json');
     fs.writeFileSync(

--- a/src/services/wordgrain/wordgrain-loader.ts
+++ b/src/services/wordgrain/wordgrain-loader.ts
@@ -55,6 +55,19 @@ function isValidGrain(obj: unknown): obj is Grain {
   if (record['sentiment'] !== undefined && typeof record['sentiment'] !== 'string') return false;
   if (record['sentiment_score'] !== undefined && typeof record['sentiment_score'] !== 'number')
     return false;
+  if (record['tfidf'] !== undefined) {
+    if (typeof record['tfidf'] !== 'number' || record['tfidf'] < 0) return false;
+  }
+  if (record['categories'] !== undefined) {
+    if (!Array.isArray(record['categories'])) return false;
+    if (!record['categories'].every((c: unknown) => typeof c === 'string')) return false;
+  }
+  if (record['collocations'] !== undefined) {
+    if (!Array.isArray(record['collocations'])) return false;
+    if (!record['collocations'].every((c: unknown) => typeof c === 'string')) return false;
+  }
+  if (record['is_slang'] !== undefined && typeof record['is_slang'] !== 'boolean') return false;
+  if (record['definition'] !== undefined && typeof record['definition'] !== 'string') return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary

Implements issue #164 by extending the wordgrain integration to leverage additional spec v0.2.0 fields (`tfidf`, `categories`, `collocations`, `is_slang`, `definition`) for more natural, context-aware vocabulary usage in reactions.

- Extend `Grain` and `VocabularyWord` types with new optional fields
- Add validation for all new fields in `isValidGrain()`
- Extract and merge new fields in vocabulary-extractor (max tfidf, dedupe arrays, OR slang)
- Boost `weightedSample` with tfidf factor so distinctive words surface more often
- Add collocation hints, category grouping, slang hints, and sentiment behavioral rules to reaction prompts

## Changes

- **types.ts**: Add `tfidf`, `categories`, `collocations`, `is_slang`, `definition` to `Grain`; add `tfidf`, `collocations`, `categories`, `isSlang` to `VocabularyWord`
- **wordgrain-loader.ts**: Validate new fields (type, range, array element types)
- **vocabulary-extractor.ts**: Extract new fields, merge duplicates (max tfidf, dedupe arrays, OR isSlang)
- **prompts.ts**: tfidf weight boost, `buildCollocationHints()`, `buildCategoryHints()`, `buildSlangHints()`, sentiment tone-matching rule
- **Test files**: Comprehensive tests for validation, extraction, merging, and prompt generation

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:unit` passes (851 tests)
- [x] `pnpm ci:all` passes
- [x] All new fields are backward compatible (optional)