### PR TITLE
Fix splash screen flicker by removing redundant resize handler call

### DIFF
--- a/src/ui/hooks/useTerminalSize.ts
+++ b/src/ui/hooks/useTerminalSize.ts
@@ -29,7 +29,6 @@ export function useTerminalSize(): TerminalSize {
     };
 
     stdout.on('resize', handleResize);
-    handleResize();
 
     return () => {
       stdout.off('resize', handleResize);


### PR DESCRIPTION
## Summary



## Changes

- Remove redundant handleResize call in useTerminalSize to prevent splash flicker

Resolves #201