### PR TITLE
Fix UI rendering artifacts: duplicate header, stacking loading text, and border ghosts (#206)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -11,6 +11,7 @@ import { SplashScreen } from './components/splash/SplashScreen.js';
 import { WriteView } from './components/write/WriteView.js';
 import { NavigationProvider, useNavigation } from './context/NavigationContext.js';
 import { useQueue } from './context/QueueContext.js';
+import { useTerminalSize } from './hooks/useTerminalSize.js';
 
 function AppContent() {
   const { exit } = useApp();
@@ -19,6 +20,13 @@ function AppContent() {
   const [isViewingDetail, setIsViewingDetail] = useState(false);
   const agentStatus = useAgentStatus();
   useTerminalTitle(agentStatus);
+  const { rows: terminalRows } = useTerminalSize();
+
+  // Fixed content height keeps total output height constant across mode switches.
+  // This prevents Ink's incremental renderer from leaving ghost lines when
+  // the rendered height changes (e.g. duplicate headers, stacked borders).
+  // Overhead: header(4) + footer(2) + 1 buffer = 7
+  const contentHeight = Math.max(5, terminalRows - 7);
 
   useInput((input, key) => {
     if (input === 'q' || (key.ctrl && input === 'c')) {
@@ -46,7 +54,7 @@ function AppContent() {
         </Box>
       </Box>
 
-      <Box flexGrow={1}>
+      <Box flexGrow={1} height={contentHeight} overflow="hidden">
         {mode === 'list' && <EntryList onViewingDetailChange={setIsViewingDetail} />}
         {mode === 'write' && <WriteView />}
         {mode === 'config' && <ConfigView />}

--- a/src/ui/hooks/useEntries.ts
+++ b/src/ui/hooks/useEntries.ts
@@ -17,29 +17,38 @@ export interface UseEntriesResult {
 
 export function useEntries(options: UseEntriesOptions = {}): UseEntriesResult {
   const { entryService } = useServices();
-  const [entries, setEntries] = useState<JournalEntry[]>([]);
-  const [loading, setLoading] = useState(true);
+
+  const buildListOptions = useCallback(
+    (): ListEntriesOptions => ({
+      limit: options.limit,
+      sortBy: options.sortBy ?? 'timestamp',
+      order: options.order ?? 'desc',
+    }),
+    [options.limit, options.sortBy, options.order],
+  );
+
+  // Initialize entries synchronously to avoid a "Loading entries..." flash
+  // on every mount. entryService.list() is synchronous (SQLite), so we can
+  // populate data immediately without a loading state.
+  const [entries, setEntries] = useState<JournalEntry[]>(() => {
+    try {
+      return entryService.list(buildListOptions());
+    } catch {
+      return [];
+    }
+  });
   const [error, setError] = useState<Error | null>(null);
 
   const fetchEntries = useCallback(() => {
-    setLoading(true);
     setError(null);
 
     try {
-      const listOptions: ListEntriesOptions = {
-        limit: options.limit,
-        sortBy: options.sortBy ?? 'timestamp',
-        order: options.order ?? 'desc',
-      };
-
-      const result = entryService.list(listOptions);
+      const result = entryService.list(buildListOptions());
       setEntries(result);
     } catch (err) {
       setError(err instanceof Error ? err : new Error('Failed to fetch entries'));
-    } finally {
-      setLoading(false);
     }
-  }, [entryService, options.limit, options.sortBy, options.order]);
+  }, [entryService, buildListOptions]);
 
   useEffect(() => {
     fetchEntries();
@@ -47,7 +56,7 @@ export function useEntries(options: UseEntriesOptions = {}): UseEntriesResult {
 
   return {
     entries,
-    loading,
+    loading: false,
     error,
     refetch: fetchEntries,
   };


### PR DESCRIPTION
## Summary

Fixes three Ink incremental rendering bugs that caused ghost UI artifacts during mode switches. Fixes #206.

- Duplicate header row when switching between Write/List modes
- Accumulating "Loading entries..." messages on each return to List mode
- Multiple green input box borders stacking in Write mode

## Changes

- **src/ui/App.tsx**: Set fixed content height based on terminal size with `overflow="hidden"` to keep total output height constant across mode switches, preventing Ink's incremental renderer from leaving ghost lines
- **src/ui/hooks/useEntries.ts**: Initialize entries synchronously in `useState` initializer (SQLite is sync) to eliminate the "Loading entries..." flash on every EntryList mount

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 851 tests pass
- [ ] Manual: Switch between Write and List modes multiple times — no duplicate headers
- [ ] Manual: Navigate to List mode repeatedly — no stacking "Loading entries..." text
- [ ] Manual: Enter Write mode multiple times — no stacking green borders