### PR TITLE
Add hard dedup check for LLM reactions with retry fallback (#209)

### DIFF
--- a/src/services/reaction-service.test.ts
+++ b/src/services/reaction-service.test.ts
@@ -4,6 +4,7 @@ import { initializeSchema } from '../infrastructure/database/schema.js';
 import {
   type ReactionServiceInterface,
   createReactionService,
+  isDuplicate,
   isLikelyBrokenJapanese,
 } from './reaction-service.js';
 
@@ -36,6 +37,24 @@ describe('isLikelyBrokenJapanese', () => {
   it('should allow 4-char or shorter strings', () => {
     expect(isLikelyBrokenJapanese('あいう', 'ja')).toBe(false);
     expect(isLikelyBrokenJapanese('あいうえ', 'ja')).toBe(false);
+  });
+});
+
+describe('isDuplicate', () => {
+  it('should detect exact duplicates', () => {
+    expect(isDuplicate('きつそう', ['きつそう', 'やば'])).toBe(true);
+  });
+
+  it('should detect duplicates with whitespace differences', () => {
+    expect(isDuplicate(' きつそう ', ['きつそう', 'やば'])).toBe(true);
+  });
+
+  it('should return false for non-duplicates', () => {
+    expect(isDuplicate('new reaction', ['きつそう', 'やば'])).toBe(false);
+  });
+
+  it('should return false for empty recent list', () => {
+    expect(isDuplicate('anything', [])).toBe(false);
   });
 });
 
@@ -368,6 +387,63 @@ describe('ReactionService', () => {
 
       expect(reaction?.content).toBe('きつそう');
       expect(reaction?.reactionType).toBe('custom');
+    });
+
+    it('should retry once and use fallback when LLM returns duplicate both times', async () => {
+      const mockLLMService = {
+        react: vi.fn().mockResolvedValue({ content: 'きつそう' }),
+      };
+
+      const llmService = createReactionService(
+        db,
+        { useLLM: true, language: 'ja' },
+        mockLLMService as unknown as Parameters<typeof createReactionService>[2],
+      );
+
+      // Insert additional entry
+      db.prepare(
+        `INSERT INTO entries (id, timestamp, content, metadata, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run('entry-2', Date.now() / 1000, 'Content 2', '{}', Date.now() / 1000, Date.now() / 1000);
+
+      // First call succeeds
+      const r1 = await llmService.generateReaction('entry-1', 'test content');
+      expect(r1?.content).toBe('きつそう');
+      expect(mockLLMService.react).toHaveBeenCalledTimes(1);
+
+      // Second call: LLM returns same value both attempts, falls back to default
+      const r2 = await llmService.generateReaction('entry-2', 'more content');
+      expect(r2?.content).toBe('·');
+      // 2 retry attempts
+      expect(mockLLMService.react).toHaveBeenCalledTimes(3);
+    });
+
+    it('should accept LLM response on retry when second attempt is unique', async () => {
+      const mockLLMService = {
+        react: vi
+          .fn()
+          .mockResolvedValueOnce({ content: 'きつそう' })
+          // Second call (first for entry-2): returns duplicate
+          .mockResolvedValueOnce({ content: 'きつそう' })
+          // Third call (retry for entry-2): returns unique value
+          .mockResolvedValueOnce({ content: 'わかる' }),
+      };
+
+      const llmService = createReactionService(
+        db,
+        { useLLM: true, language: 'ja' },
+        mockLLMService as unknown as Parameters<typeof createReactionService>[2],
+      );
+
+      db.prepare(
+        `INSERT INTO entries (id, timestamp, content, metadata, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run('entry-2', Date.now() / 1000, 'Content 2', '{}', Date.now() / 1000, Date.now() / 1000);
+
+      await llmService.generateReaction('entry-1', 'test content');
+      const r2 = await llmService.generateReaction('entry-2', 'more content');
+      expect(r2?.content).toBe('わかる');
+      expect(mockLLMService.react).toHaveBeenCalledTimes(3);
     });
 
     it('should pass recent reactions to LLM after generating reactions', async () => {

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -34,6 +34,14 @@ const DEFAULT_CONFIG: ReactionConfig = {
 const RECENT_REACTION_LIMIT = 8;
 
 /**
+ * Check if a candidate reaction is a duplicate of any recent reaction.
+ */
+export function isDuplicate(candidate: string, recent: string[]): boolean {
+  const normalized = candidate.trim();
+  return recent.some((r) => r.trim() === normalized);
+}
+
+/**
  * Detect likely broken Japanese output.
  * All-hiragana strings longer than 6 characters are almost certainly
  * garbled output from the LLM rather than intentional reactions.
@@ -174,7 +182,7 @@ export function createReactionService(
 
     seedRecentReactions();
 
-    let reactionContent: string;
+    let reactionContent = '';
     let reactionType: ReactionType = currentConfig.defaultReactionType;
 
     if (currentConfig.useLLM && llmService) {
@@ -185,21 +193,32 @@ export function createReactionService(
           .filter((e) => e.id !== entryId)
           .slice(0, 3)
           .map((e) => e.content);
-        const response = await llmService.react(content, {
-          language,
-          recentEntries,
-          recentReactions: recentReactions.length > 0 ? [...recentReactions] : undefined,
-        });
-        const trimmed = response.content.trim();
-        // Use LLM response if non-empty, short enough, and not broken Japanese
-        if (
-          trimmed &&
-          trimmed.length <= MAX_REACTION_LENGTH &&
-          !isLikelyBrokenJapanese(trimmed, language)
-        ) {
-          reactionContent = trimmed;
-          reactionType = 'custom';
-        } else {
+
+        const MAX_DEDUP_ATTEMPTS = 2;
+        let accepted = false;
+
+        for (let attempt = 0; attempt < MAX_DEDUP_ATTEMPTS; attempt++) {
+          const response = await llmService.react(content, {
+            language,
+            recentEntries,
+            recentReactions: recentReactions.length > 0 ? [...recentReactions] : undefined,
+          });
+          const trimmed = response.content.trim();
+
+          if (
+            trimmed &&
+            trimmed.length <= MAX_REACTION_LENGTH &&
+            !isLikelyBrokenJapanese(trimmed, language) &&
+            !isDuplicate(trimmed, recentReactions)
+          ) {
+            reactionContent = trimmed;
+            reactionType = 'custom';
+            accepted = true;
+            break;
+          }
+        }
+
+        if (!accepted) {
           reactionContent = getVocabularyFallback() ?? getDefaultContent(reactionType);
         }
       } catch {


### PR DESCRIPTION
## Summary

Fixes three Ink incremental rendering bugs that caused ghost UI artifacts during mode switches. Fixes #206.

- Duplicate header row when switching between Write/List modes
- Accumulating "Loading entries..." messages on each return to List mode
- Multiple green input box borders stacking in Write mode

## Changes

- **src/ui/App.tsx**: Set fixed content height based on terminal size with `overflow="hidden"` to keep total output height constant across mode switches, preventing Ink's incremental renderer from leaving ghost lines
- **src/ui/hooks/useEntries.ts**: Initialize entries synchronously in `useState` initializer (SQLite is sync) to eliminate the "Loading entries..." flash on every EntryList mount

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 851 tests pass
- [ ] Manual: Switch between Write and List modes multiple times — no duplicate headers
- [ ] Manual: Navigate to List mode repeatedly — no stacking "Loading entries..." text
- [ ] Manual: Enter Write mode multiple times — no stacking green borders