### PR TITLE
Add direct bar quote reaction via keyword matching

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
   const reactionConfig = getReactionConfig();
   const reactionLLMService = reactionConfig.useLLM ? llmService : undefined;
   const reactionService = createReactionService(db, reactionConfig, reactionLLMService);
+  reactionService.setFeatures(config.features);
 
   // Load wordgrain vocabulary if configured
   if (config.wordgrainFiles && config.wordgrainFiles.length > 0) {

--- a/src/services/llm/bar-index.test.ts
+++ b/src/services/llm/bar-index.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { Bar } from '../wordgrain/types.js';
+import { buildBarIndex } from './bar-index.js';
+
+const longText = (base: string): string =>
+  base.padEnd(101, ' padding text to exceed minimum length');
+
+describe('buildBarIndex', () => {
+  it('should exclude bars with 100 or fewer characters', () => {
+    const bars: Bar[] = [{ text: 'short bar text' }];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('short bar text', 'en');
+    expect(results).toHaveLength(0);
+  });
+
+  it('should include bars longer than 100 characters', () => {
+    const bars: Bar[] = [
+      { text: longText('hustle grind daily motivation never stop working hard') },
+    ];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('hustle grind', 'en');
+    expect(results).toHaveLength(1);
+  });
+
+  it('should return empty for no keyword overlap', () => {
+    const bars: Bar[] = [{ text: longText('hustle grind daily motivation never stop') }];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('sunshine rainbow', 'en');
+    expect(results).toHaveLength(0);
+  });
+
+  it('should require 2 matching tokens for English', () => {
+    const bars: Bar[] = [{ text: longText('hustle grind daily motivation never stop') }];
+    const index = buildBarIndex(bars);
+
+    // Only 1 match - should not return
+    const single = index.lookup('hustle rainbow', 'en');
+    expect(single).toHaveLength(0);
+
+    // 2 matches - should return
+    const double = index.lookup('hustle grind', 'en');
+    expect(double).toHaveLength(1);
+  });
+
+  it('should require only 1 matching token for Japanese', () => {
+    const bars: Bar[] = [
+      { text: longText('仕事は大変だけど頑張ろう毎日努力して成長していく'), language: 'ja' },
+    ];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('仕事がつらい', 'ja');
+    expect(results).toHaveLength(1);
+  });
+
+  it('should sort results by match count descending', () => {
+    const bars: Bar[] = [
+      { text: longText('hustle grind daily motivation never stop working hard everyday') },
+      {
+        text: longText(
+          'hustle grind daily motivation work hard play hard never give up on your dreams',
+        ),
+      },
+    ];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('hustle grind daily motivation', 'en');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should not match on stopwords only', () => {
+    const bars: Bar[] = [{ text: longText('the is a an this that with from for and') }];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('the is a', 'en');
+    expect(results).toHaveLength(0);
+  });
+
+  it('should handle empty bars array', () => {
+    const index = buildBarIndex([]);
+    const results = index.lookup('anything', 'en');
+    expect(results).toHaveLength(0);
+  });
+
+  it('should handle empty entry text', () => {
+    const bars: Bar[] = [{ text: longText('hustle grind daily motivation never stop') }];
+    const index = buildBarIndex(bars);
+    const results = index.lookup('', 'en');
+    expect(results).toHaveLength(0);
+  });
+
+  it('should default to en threshold when language is undefined', () => {
+    const bars: Bar[] = [{ text: longText('hustle grind daily motivation never stop') }];
+    const index = buildBarIndex(bars);
+
+    // 1 match with undefined language should not return (en threshold = 2)
+    const single = index.lookup('hustle rainbow');
+    expect(single).toHaveLength(0);
+
+    // 2 matches should return
+    const double = index.lookup('hustle grind');
+    expect(double).toHaveLength(1);
+  });
+});

--- a/src/services/llm/bar-index.ts
+++ b/src/services/llm/bar-index.ts
@@ -1,0 +1,76 @@
+/**
+ * Inverted index for O(k) bar lookup by keyword matching.
+ * Used by the bar quote feature to find bars that match journal entry text.
+ */
+
+import { tokenize } from '../../utils/tokenize.js';
+import type { DetectedLanguage } from '../language/types.js';
+import { isStopWord } from '../trends/stopwords.js';
+import type { Bar } from '../wordgrain/types.js';
+import { buildEntryTokens } from './bar-selector.js';
+
+const MIN_BAR_LENGTH = 100;
+
+export interface BarIndex {
+  lookup(entryText: string, language?: DetectedLanguage): Bar[];
+}
+
+interface BarMatch {
+  bar: Bar;
+  count: number;
+}
+
+/**
+ * Build an inverted index mapping non-stopword tokens to bars.
+ * Bars shorter than MIN_BAR_LENGTH characters are excluded.
+ */
+export function buildBarIndex(bars: Bar[]): BarIndex {
+  const index = new Map<string, Bar[]>();
+
+  for (const bar of bars) {
+    if (bar.text.length <= MIN_BAR_LENGTH) continue;
+
+    const tokens = tokenize(bar.text.toLowerCase().trim());
+    const seen = new Set<string>();
+
+    for (const token of tokens) {
+      if (isStopWord(token) || seen.has(token)) continue;
+      seen.add(token);
+
+      let list = index.get(token);
+      if (!list) {
+        list = [];
+        index.set(token, list);
+      }
+      list.push(bar);
+    }
+  }
+
+  return {
+    lookup(entryText: string, language?: DetectedLanguage): Bar[] {
+      const entryTokens = buildEntryTokens(entryText);
+      if (entryTokens.size === 0) return [];
+
+      const threshold = language === 'ja' ? 1 : 2;
+      const matchCounts = new Map<Bar, number>();
+
+      for (const token of entryTokens) {
+        const bars = index.get(token);
+        if (!bars) continue;
+        for (const bar of bars) {
+          matchCounts.set(bar, (matchCounts.get(bar) ?? 0) + 1);
+        }
+      }
+
+      const matches: BarMatch[] = [];
+      for (const [bar, count] of matchCounts) {
+        if (count >= threshold) {
+          matches.push({ bar, count });
+        }
+      }
+
+      matches.sort((a, b) => b.count - a.count);
+      return matches.map((m) => m.bar);
+    },
+  };
+}

--- a/src/services/llm/bar-quote.test.ts
+++ b/src/services/llm/bar-quote.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { Bar } from '../wordgrain/types.js';
+import type { BarIndex } from './bar-index.js';
+import { tryBarQuote } from './bar-quote.js';
+
+function createMockIndex(bars: Bar[]): BarIndex {
+  return {
+    lookup: () => bars,
+  };
+}
+
+describe('tryBarQuote', () => {
+  it('should return null when no matches found', () => {
+    const index = createMockIndex([]);
+    const result = tryBarQuote('test entry', index, [], 'en', () => 0.3);
+    expect(result).toBeNull();
+  });
+
+  it('should return a matching bar when probability passes', () => {
+    const bar: Bar = { text: 'hustle hard every day', source: { artist: 'Test' } };
+    const index = createMockIndex([bar]);
+    const result = tryBarQuote('test', index, [], 'en', () => 0.3);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe('hustle hard every day');
+    expect(result?.source?.artist).toBe('Test');
+  });
+
+  it('should return null when probability gate rejects (random > 0.6)', () => {
+    const bar: Bar = { text: 'hustle hard every day' };
+    const index = createMockIndex([bar]);
+    const result = tryBarQuote('test', index, [], 'en', () => 0.7);
+    expect(result).toBeNull();
+  });
+
+  it('should return null at exactly 0.6 boundary (> 0.6 is reject)', () => {
+    const bar: Bar = { text: 'hustle hard every day' };
+    const index = createMockIndex([bar]);
+    // 0.6 is NOT > 0.6, so it should pass
+    const result = tryBarQuote('test', index, [], 'en', () => 0.6);
+    expect(result).not.toBeNull();
+  });
+
+  it('should skip duplicate bars and return first non-duplicate', () => {
+    const bars: Bar[] = [{ text: 'already seen this' }, { text: 'fresh new bar' }];
+    const index = createMockIndex(bars);
+    const result = tryBarQuote('test', index, ['already seen this'], 'en', () => 0.3);
+    expect(result?.text).toBe('fresh new bar');
+  });
+
+  it('should return null when all matches are duplicates', () => {
+    const bars: Bar[] = [{ text: 'seen one' }, { text: 'seen two' }];
+    const index = createMockIndex(bars);
+    const result = tryBarQuote('test', index, ['seen one', 'seen two'], 'en', () => 0.3);
+    expect(result).toBeNull();
+  });
+
+  it('should work without explicit language parameter', () => {
+    const bar: Bar = { text: 'hustle hard every day' };
+    const index = createMockIndex([bar]);
+    const result = tryBarQuote('test', index, [], undefined, () => 0.3);
+    expect(result).not.toBeNull();
+  });
+
+  it('should return bar without source when source is undefined', () => {
+    const bar: Bar = { text: 'no source bar' };
+    const index = createMockIndex([bar]);
+    const result = tryBarQuote('test', index, [], 'en', () => 0.3);
+    expect(result?.text).toBe('no source bar');
+    expect(result?.source).toBeUndefined();
+  });
+});

--- a/src/services/llm/bar-quote.ts
+++ b/src/services/llm/bar-quote.ts
@@ -1,0 +1,42 @@
+/**
+ * Bar quote reaction: returns bar text directly as a reaction
+ * without going through the LLM, when keyword matching succeeds.
+ */
+
+import type { DetectedLanguage } from '../language/types.js';
+import { isDuplicate } from '../reaction-service.js';
+import type { BarSource } from '../wordgrain/types.js';
+import type { BarIndex } from './bar-index.js';
+
+export interface BarQuoteResult {
+  text: string;
+  source?: BarSource;
+}
+
+/**
+ * Attempt to find a matching bar quote for the given entry text.
+ *
+ * Returns null if no match, probability gate rejects, or all matches are duplicates.
+ * The probability gate skips ~40% of the time to keep bar quotes feeling organic.
+ */
+export function tryBarQuote(
+  entryText: string,
+  barIndex: BarIndex,
+  recentReactions: string[],
+  language?: DetectedLanguage,
+  random?: () => number,
+): BarQuoteResult | null {
+  const matches = barIndex.lookup(entryText, language);
+  if (matches.length === 0) return null;
+
+  // Probability gate: skip ~40% of the time
+  if ((random ?? Math.random)() > 0.6) return null;
+
+  for (const bar of matches) {
+    if (!isDuplicate(bar.text, recentReactions)) {
+      return { text: bar.text, source: bar.source };
+    }
+  }
+
+  return null;
+}

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -1,10 +1,13 @@
 import type { Database as DatabaseType } from 'better-sqlite3';
+import type { MumblFeatures } from '../config/types.js';
 import { createEntryRepository } from '../repositories/entry-repository.js';
 import { createReactionRepository } from '../repositories/reaction-repository.js';
 import type { Reaction, ReactionType } from '../repositories/types.js';
 import { generateEntryId } from './id-service.js';
 import { detectLanguage } from './language/detect.js';
 import type { DetectedLanguage } from './language/types.js';
+import { type BarIndex, buildBarIndex } from './llm/bar-index.js';
+import { tryBarQuote } from './llm/bar-quote.js';
 import type { LLMServiceInterface } from './llm/llm-service.js';
 import type { VocabularySet } from './wordgrain/types.js';
 
@@ -78,6 +81,7 @@ export interface ReactionServiceInterface {
   updateConfig(config: Partial<ReactionConfig>): void;
   getConfig(): ReactionConfig;
   setVocabulary(vocabulary: VocabularySet): void;
+  setFeatures(features: MumblFeatures): void;
 }
 
 /**
@@ -106,11 +110,18 @@ export function createReactionService(
   const entryRepository = createEntryRepository(db);
   let currentConfig: ReactionConfig = { ...DEFAULT_CONFIG, ...config };
   let vocabulary: VocabularySet | undefined;
+  let features: MumblFeatures = {};
+  let barIndex: BarIndex | undefined;
   const recentReactions: string[] = [];
   let seededFromDb = false;
 
   const setVocabulary = (v: VocabularySet): void => {
     vocabulary = v;
+    barIndex = v.bars && v.bars.length > 0 ? buildBarIndex(v.bars) : undefined;
+  };
+
+  const setFeatures = (f: MumblFeatures): void => {
+    features = f;
   };
 
   const getVocabularyFallback = (): string | undefined => {
@@ -181,6 +192,28 @@ export function createReactionService(
     }
 
     seedRecentReactions();
+
+    // Try bar quote path before LLM (when feature flag is enabled)
+    if (features.barQuote && barIndex) {
+      const language = resolveLanguage(content);
+      const quote = tryBarQuote(content, barIndex, recentReactions, language);
+      if (quote) {
+        const reaction: Reaction = {
+          id: generateEntryId(),
+          entryId,
+          reactionType: 'custom',
+          content: quote.text,
+          createdAt: new Date(),
+        };
+        recentReactions.push(quote.text);
+        if (recentReactions.length > RECENT_REACTION_LIMIT) {
+          recentReactions.shift();
+        }
+        repository.insert(reaction);
+        emit('reactionCreated', reaction);
+        return reaction;
+      }
+    }
 
     let reactionContent = '';
     let reactionType: ReactionType = currentConfig.defaultReactionType;
@@ -289,5 +322,6 @@ export function createReactionService(
     updateConfig,
     getConfig,
     setVocabulary,
+    setFeatures,
   };
 }

--- a/src/ui/context/ConfigContext.tsx
+++ b/src/ui/context/ConfigContext.tsx
@@ -144,8 +144,9 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
       const updated = { ...features, [key]: !features[key] };
       setFeatures(updated);
       saveConfigFile({ features: updated });
+      reactionService.setFeatures(updated);
     },
-    [features],
+    [features, reactionService],
   );
 
   return (


### PR DESCRIPTION
## Summary

Implements issue #212 by adding a keyword-matching path that returns bar text as reactions without going through the LLM. Fires before the LLM call and is gated behind the existing `barQuote` feature flag (default: OFF).

- Build inverted index from bars for O(k) keyword lookups
- Add probability gate (40% skip) and dedup checking
- Integrate into reaction service before LLM path

## Changes

- **src/services/llm/bar-index.ts**: New inverted index mapping non-stopword tokens to bars (>100 chars). Threshold: ja=1 match, en=2 matches.
- **src/services/llm/bar-quote.ts**: Orchestrates bar quote attempts with probability gate and dedup via `isDuplicate()`.
- **src/services/reaction-service.ts**: Added `setFeatures()` method, bar index build in `setVocabulary()`, bar quote check before LLM call in `generateReaction()`.
- **src/index.tsx**: Pass initial features to reaction service at startup.
- **src/ui/context/ConfigContext.tsx**: Propagate feature toggle to reaction service on change.
- **src/services/llm/bar-index.test.ts**: 10 tests covering index construction, thresholds, stopword filtering, edge cases.
- **src/services/llm/bar-quote.test.ts**: 8 tests covering probability gate, dedup, no-match, boundary cases.

## Test plan

- [ ] Feature flag OFF (default): bar quote never fires, LLM path only
- [ ] Feature flag ON via config UI (c -> f -> toggle): bar quotes appear for keyword matches
- [ ] Bar quotes are deduplicated against recent reactions
- [ ] Probability gate prevents bar quotes from being too frequent
- [ ] All existing tests continue to pass

Resolves #212