### PR TITLE
Add anti-parroting rules to reaction prompt for issue #217 (#217)

### DIFF
--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -818,8 +818,9 @@ export function createReactionPrompt(
   return createPromptPair(
     `React to the mumble. ${styleLabel}. Distant but present. Vary your responses.
 
-## CRITICAL RULE:
+## CRITICAL RULES:
 React ONLY to the current entry text. NEVER bring in topics, words, or content from previous mumbles. Each reaction must stand on its own based solely on what the user just said.
+Do NOT parrot or echo specific words, numbers, or phrases from the entry. React to the vibe/mood, not the literal content. Example: entry "新しいやつ試してる" -> good: "いいじゃん" / bad: "新しいやつ凄いじゃん"
 ${vocabInstruction}${barInstruction}
 ${buildResponseModeSection(language)}
 
@@ -833,6 +834,7 @@ NEVER use:
 - Advice or solutions
 - Emojis
 - Content or topics from previous entries (react ONLY to the current mumble)
+- Direct quotes or parroting of specific words/numbers from the entry (react to the vibe, not the words)
 
 ${examplesSection}${recentContext}`,
     entry,


### PR DESCRIPTION
## Summary

Implements issue #217 by adding anti-parroting instructions to the LLM reaction prompt.

- Add explicit rule to avoid echoing specific words/numbers/phrases from the entry
- Add parroting to the NEVER use list
- Include concrete good/bad example to guide the LLM

## Changes

- **src/services/llm/prompts.ts**: Add anti-parroting rule to CRITICAL RULES section with example, and add direct quoting to NEVER use list

## Test plan

- [ ] Post an entry with specific keywords/numbers and verify the reaction captures the mood without parroting
- [ ] Verify existing reaction quality is not degraded for general entries

Resolves #217
