### PR TITLE
Diversify Japanese reaction length with more short-sentence responses (#223)

### DIFF
--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -704,10 +704,10 @@ BANNED in Japanese:
   }
 
   return `## Response modes:
-1. Short phrase, 1-5 words (~45% of the time): A casual reaction that feels natural.
-2. Single word (~25%): One word that captures the vibe.
-3. "·" (~25%): For mundane, low-energy, or routine entries. Just a read receipt.
-4. Short sentence (~5%, ONLY for highly emotional/significant entries).`;
+1. Short phrase, 1-5 words (~40%): A casual reaction that feels natural.
+2. Single word (~20%): One word that captures the vibe.
+3. "·" (~20%): For mundane, low-energy, or routine entries. Just a read receipt.
+4. Short sentence, 1 casual sentence (~20%): A natural one-liner reaction. Not limited to emotional entries.`;
 }
 
 function buildMoodMappingSection(language?: DetectedLanguage): string {


### PR DESCRIPTION
## Summary

Implements issue #223 by adjusting Japanese reaction prompts to allow longer responses more frequently, reducing the monotony of single-word-only reactions.

- Increase short sentence ratio from 5% to 20% and remove the "emotional entries only" restriction
- Add longer examples to mood mapping and examples section
- Keep short reactions as the majority, but with more natural variety

## Changes

- **src/services/llm/prompts.ts**:
  - `buildResponseModeSection`: Rebalance Japanese response mode distribution (short phrase 40%, single word 20%, "·" 20%, short sentence 20%)
  - `buildMoodMappingSection`: Add one longer example per mood category (e.g. それはきついな, それは最高だな, まじで言ってる？)
  - `buildExamplesSection`: Add 4 short-sentence examples alongside existing short ones (e.g. それは行くしかないでしょ, たしかに最近聞かないな)

## Test plan

- [ ] pnpm type-check passes
- [ ] pnpm lint passes
- [ ] All 966 unit tests pass
- [ ] Deploy and verify Japanese reactions show mix of short and longer responses

Resolves #223