### PR TITLE
Restrict wordgrain to single file selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Wordgrain files (`.wg.json`) let you infuse the AI's reactions with your own voc
 }
 ```
 
-Register files in Config mode (`c` → `a`) or in the config file:
+Set a file in Config mode (`c` → `a`) or in the config file:
 
 ```json
 {
-  "wordgrainFiles": ["/path/to/vocab.wg.json"]
+  "wordgrainFile": "/path/to/vocab.wg.json"
 }
 ```
 
@@ -127,7 +127,7 @@ Config file: `~/.config/mumbl/config.json`
 {
   "model": "llama3.1:8b",
   "baseUrl": "http://localhost:11434",
-  "wordgrainFiles": []
+  "wordgrainFile": ""
 }
 ```
 

--- a/src/config/ConfigFile.test.ts
+++ b/src/config/ConfigFile.test.ts
@@ -54,36 +54,57 @@ describe('config-file', () => {
       expect(result.baseUrl).toBe('http://localhost:8080');
     });
 
-    it('should parse valid config file with wordgrainFiles', () => {
+    it('should parse valid config file with wordgrainFile', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ wordgrainFile: '/path/to/a.wg.json' }),
+      );
+      const result = loadConfigFile();
+      expect(result.wordgrainFile).toBe('/path/to/a.wg.json');
+    });
+
+    it('should migrate old wordgrainFiles array to single wordgrainFile', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ wordgrainFiles: ['/path/to/a.wg.json', '/path/to/b.wg.json'] }),
       );
       const result = loadConfigFile();
-      expect(result.wordgrainFiles).toEqual(['/path/to/a.wg.json', '/path/to/b.wg.json']);
+      expect(result.wordgrainFile).toBe('/path/to/a.wg.json');
     });
 
-    it('should ignore non-array wordgrainFiles values', () => {
+    it('should prefer new wordgrainFile over old wordgrainFiles', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainFiles: 'not-array' }));
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          wordgrainFile: '/path/to/new.wg.json',
+          wordgrainFiles: ['/path/to/old.wg.json'],
+        }),
+      );
       const result = loadConfigFile();
-      expect(result.wordgrainFiles).toBeUndefined();
+      expect(result.wordgrainFile).toBe('/path/to/new.wg.json');
     });
 
-    it('should filter non-string entries from wordgrainFiles', () => {
+    it('should ignore non-string wordgrainFile values', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainFile: 123 }));
+      const result = loadConfigFile();
+      expect(result.wordgrainFile).toBeUndefined();
+    });
+
+    it('should migrate old array format filtering non-string entries', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ wordgrainFiles: ['/valid.wg.json', 123, null] }),
       );
       const result = loadConfigFile();
-      expect(result.wordgrainFiles).toEqual(['/valid.wg.json']);
+      expect(result.wordgrainFile).toBe('/valid.wg.json');
     });
 
-    it('should not set wordgrainFiles for empty array after filtering', () => {
+    it('should not set wordgrainFile for empty array after filtering', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ wordgrainFiles: [123, null] }));
       const result = loadConfigFile();
-      expect(result.wordgrainFiles).toBeUndefined();
+      expect(result.wordgrainFile).toBeUndefined();
     });
 
     it('should parse valid config file with all fields', () => {
@@ -93,14 +114,14 @@ describe('config-file', () => {
           model: 'qwen2.5-coder:7b',
           provider: 'ollama',
           baseUrl: 'http://localhost:8080',
-          wordgrainFiles: ['/path/to/vocab.wg.json'],
+          wordgrainFile: '/path/to/vocab.wg.json',
         }),
       );
       const result = loadConfigFile();
       expect(result.model).toBe('qwen2.5-coder:7b');
       expect(result.provider).toBe('ollama');
       expect(result.baseUrl).toBe('http://localhost:8080');
-      expect(result.wordgrainFiles).toEqual(['/path/to/vocab.wg.json']);
+      expect(result.wordgrainFile).toBe('/path/to/vocab.wg.json');
     });
 
     it('should return empty object for malformed JSON', () => {
@@ -196,7 +217,7 @@ describe('config-file', () => {
       vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
       vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
 
-      saveConfigFile({ wordgrainFiles: ['/path/to/file.wg.json'] });
+      saveConfigFile({ wordgrainFile: '/path/to/file.wg.json' });
 
       expect(fs.mkdirSync).toHaveBeenCalledWith(path.join('/home/user', '.config', 'mumbl'), {
         recursive: true,
@@ -204,7 +225,7 @@ describe('config-file', () => {
       expect(fs.writeFileSync).toHaveBeenCalled();
       const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
       const written = JSON.parse((writeCall?.[1] as string).trim());
-      expect(written.wordgrainFiles).toEqual(['/path/to/file.wg.json']);
+      expect(written.wordgrainFile).toBe('/path/to/file.wg.json');
     });
 
     it('should merge with existing config file', () => {
@@ -214,13 +235,28 @@ describe('config-file', () => {
       );
       vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
 
-      saveConfigFile({ wordgrainFiles: ['/path/to/file.wg.json'] });
+      saveConfigFile({ wordgrainFile: '/path/to/file.wg.json' });
 
       const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
       const written = JSON.parse((writeCall?.[1] as string).trim());
       expect(written.model).toBe('llama2');
       expect(written.provider).toBe('ollama');
-      expect(written.wordgrainFiles).toEqual(['/path/to/file.wg.json']);
+      expect(written.wordgrainFile).toBe('/path/to/file.wg.json');
+    });
+
+    it('should clean up old wordgrainFiles key when saving wordgrainFile', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ wordgrainFiles: ['/old.wg.json'] }),
+      );
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+      saveConfigFile({ wordgrainFile: '/new.wg.json' });
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const written = JSON.parse((writeCall?.[1] as string).trim());
+      expect(written.wordgrainFile).toBe('/new.wg.json');
+      expect(written.wordgrainFiles).toBeUndefined();
     });
 
     it('should handle malformed existing config gracefully', () => {
@@ -228,11 +264,11 @@ describe('config-file', () => {
       vi.mocked(fs.readFileSync).mockReturnValue('invalid json');
       vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
 
-      saveConfigFile({ wordgrainFiles: [] });
+      saveConfigFile({ wordgrainFile: '' });
 
       const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
       const written = JSON.parse((writeCall?.[1] as string).trim());
-      expect(written.wordgrainFiles).toEqual([]);
+      expect(written.wordgrainFile).toBe('');
     });
 
     it('should save features to config file', () => {

--- a/src/config/ConfigFile.ts
+++ b/src/config/ConfigFile.ts
@@ -51,10 +51,13 @@ export function loadConfigFile(): Partial<MumblConfig> {
       result.baseUrl = config['baseUrl'];
     }
 
-    if (Array.isArray(config['wordgrainFiles'])) {
+    // Support new single-file format and migrate old array format
+    if (typeof config['wordgrainFile'] === 'string') {
+      result.wordgrainFile = config['wordgrainFile'];
+    } else if (Array.isArray(config['wordgrainFiles'])) {
       const files = config['wordgrainFiles'].filter((f: unknown) => typeof f === 'string');
       if (files.length > 0) {
-        result.wordgrainFiles = files;
+        result.wordgrainFile = files[0];
       }
     }
 
@@ -107,8 +110,10 @@ export function saveConfigFile(update: Partial<MumblConfig>): void {
   if (update.model !== undefined) existing['model'] = update.model;
   if (update.provider !== undefined) existing['provider'] = update.provider;
   if (update.baseUrl !== undefined) existing['baseUrl'] = update.baseUrl;
-  if (update.wordgrainFiles !== undefined) {
-    existing['wordgrainFiles'] = update.wordgrainFiles;
+  if (update.wordgrainFile !== undefined) {
+    existing['wordgrainFile'] = update.wordgrainFile;
+    // Clean up old array format
+    delete existing['wordgrainFiles'];
   }
   if (update.features !== undefined) {
     const existingFeatures =

--- a/src/config/ResolveConfig.ts
+++ b/src/config/ResolveConfig.ts
@@ -30,7 +30,7 @@ export function resolveConfig(cliArgs?: string[]): ResolvedConfig {
 
   const baseUrl = sources.cli.baseUrl ?? sources.env.baseUrl ?? sources.file.baseUrl;
 
-  const wordgrainFiles = sources.file.wordgrainFiles;
+  const wordgrainFile = sources.file.wordgrainFile;
 
   const features: MumblFeatures = { ...DEFAULT_FEATURES, ...sources.file.features };
 
@@ -38,7 +38,7 @@ export function resolveConfig(cliArgs?: string[]): ResolvedConfig {
     provider: 'ollama',
     model,
     baseUrl,
-    wordgrainFiles,
+    wordgrainFile,
     features,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -17,7 +17,7 @@ export interface MumblConfig {
   model?: string;
   provider?: Provider;
   baseUrl?: string;
-  wordgrainFiles?: string[];
+  wordgrainFile?: string;
   features?: MumblFeatures;
 }
 
@@ -28,7 +28,7 @@ export interface ResolvedConfig {
   model: string;
   provider: Provider;
   baseUrl?: string;
-  wordgrainFiles?: string[];
+  wordgrainFile?: string;
   features: MumblFeatures;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,8 +56,8 @@ import { ServiceProvider } from './ui/context/ServiceContext.js';
   reactionService.setFeatures(config.features);
 
   // Load wordgrain vocabulary if configured
-  if (config.wordgrainFiles && config.wordgrainFiles.length > 0) {
-    const vocabulary = loadVocabulary(config.wordgrainFiles);
+  if (config.wordgrainFile) {
+    const vocabulary = loadVocabulary(config.wordgrainFile);
     if (vocabulary) {
       llmService.setVocabulary(vocabulary);
       reactionService.setVocabulary(vocabulary);

--- a/src/services/wordgrain/VocabularyExtractor.test.ts
+++ b/src/services/wordgrain/VocabularyExtractor.test.ts
@@ -4,11 +4,13 @@ import type { WordgrainFile } from './types.js';
 
 describe('extractVocabulary', () => {
   it('should extract words from grains', () => {
-    const files: WordgrainFile[] = [
-      { name: 'test', grains: [{ word: 'drip' }, { word: 'flex' }], bars: [] },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'drip' }, { word: 'flex' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual(['drip', 'flex']);
     expect(result.phrases).toEqual([]);
@@ -16,121 +18,117 @@ describe('extractVocabulary', () => {
   });
 
   it('should separate multi-word grains as phrases', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [{ word: 'drip' }, { word: 'go hard' }, { word: 'no cap' }],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'drip' }, { word: 'go hard' }, { word: 'no cap' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual(['drip']);
     expect(result.phrases).toEqual(['go hard', 'no cap']);
   });
 
-  it('should deduplicate words and phrases', () => {
-    const files: WordgrainFile[] = [
-      { name: 'a', grains: [{ word: 'drip' }, { word: 'flex' }], bars: [] },
-      { name: 'b', grains: [{ word: 'drip' }, { word: 'fire' }], bars: [] },
-    ];
+  it('should deduplicate words within the same file', () => {
+    const file: WordgrainFile = {
+      name: 'a',
+      grains: [{ word: 'drip' }, { word: 'flex' }, { word: 'drip' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
-    expect(result.words).toEqual(['drip', 'fire', 'flex']);
+    expect(result.words).toEqual(['drip', 'flex']);
   });
 
   it('should collect and deduplicate tags', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'drip', tags: ['style', 'fashion'] },
-          { word: 'flex', tags: ['style', 'money'] },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', tags: ['style', 'fashion'] },
+        { word: 'flex', tags: ['style', 'money'] },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.tags).toEqual(['fashion', 'money', 'style']);
   });
 
-  it('should return empty arrays for empty input', () => {
-    const result = extractVocabulary([]);
+  it('should return empty arrays for file with no grains', () => {
+    const file: WordgrainFile = { name: 'empty', grains: [], bars: [] };
+
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual([]);
     expect(result.phrases).toEqual([]);
     expect(result.tags).toEqual([]);
-    expect(result.source).toBe('');
+    expect(result.source).toBe('empty');
     expect(result.bars).toEqual([]);
   });
 
   it('should skip empty/whitespace-only words', () => {
-    const files: WordgrainFile[] = [
-      { name: 'test', grains: [{ word: '' }, { word: '   ' }, { word: 'valid' }], bars: [] },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: '' }, { word: '   ' }, { word: 'valid' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual(['valid']);
   });
 
   it('should sort words and phrases alphabetically', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [{ word: 'zap' }, { word: 'ace' }, { word: 'no cap' }, { word: 'all day' }],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'zap' }, { word: 'ace' }, { word: 'no cap' }, { word: 'all day' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual(['ace', 'zap']);
     expect(result.phrases).toEqual(['all day', 'no cap']);
   });
 
-  it('should join multiple file names as source', () => {
-    const files: WordgrainFile[] = [
-      { name: 'future', grains: [{ word: 'drip' }], bars: [] },
-      { name: 'travis', grains: [{ word: 'flame' }], bars: [] },
-    ];
+  it('should use file name as source', () => {
+    const file: WordgrainFile = {
+      name: 'future',
+      grains: [{ word: 'drip' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
-    expect(result.source).toBe('future, travis');
+    expect(result.source).toBe('future');
   });
 
   it('should skip empty tags', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [{ word: 'drip', tags: ['style', '', '  '] }],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'drip', tags: ['style', '', '  '] }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.tags).toEqual(['style']);
   });
 
   it('should generate richWords with pos and frequency metadata', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'drip', pos: 'noun', frequency: 42 },
-          { word: 'flex', pos: 'verb', frequency: 10 },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', pos: 'noun', frequency: 42 },
+        { word: 'flex', pos: 'verb', frequency: 10 },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(2);
     expect(result.richWords[0]).toEqual({ word: 'drip', pos: 'noun', frequency: 42 });
@@ -138,11 +136,13 @@ describe('extractVocabulary', () => {
   });
 
   it('should generate richWords without metadata when pos/frequency absent', () => {
-    const files: WordgrainFile[] = [
-      { name: 'test', grains: [{ word: 'chill' }, { word: 'vibe' }], bars: [] },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'chill' }, { word: 'vibe' }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(2);
     expect(result.richWords[0]).toEqual({ word: 'chill' });
@@ -150,39 +150,33 @@ describe('extractVocabulary', () => {
   });
 
   it('should merge duplicate words keeping max frequency and first pos', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'a',
-        grains: [{ word: 'drip', pos: 'noun', frequency: 10 }],
-        bars: [],
-      },
-      {
-        name: 'b',
-        grains: [{ word: 'drip', pos: 'verb', frequency: 50 }],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', pos: 'noun', frequency: 10 },
+        { word: 'drip', pos: 'verb', frequency: 50 },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(1);
     expect(result.richWords[0]).toEqual({ word: 'drip', pos: 'noun', frequency: 50 });
   });
 
   it('should handle mixed grains with and without metadata', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'drip', pos: 'noun', frequency: 42 },
-          { word: 'chill' },
-          { word: 'flex', frequency: 5 },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', pos: 'noun', frequency: 42 },
+        { word: 'chill' },
+        { word: 'flex', frequency: 5 },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(3);
     expect(result.richWords[0]).toEqual({ word: 'chill' });
@@ -190,89 +184,75 @@ describe('extractVocabulary', () => {
     expect(result.richWords[2]).toEqual({ word: 'flex', frequency: 5 });
   });
 
-  it('should return empty richWords for empty input', () => {
-    const result = extractVocabulary([]);
+  it('should return empty richWords for file with no grains', () => {
+    const file: WordgrainFile = { name: 'empty', grains: [], bars: [] };
+
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toEqual([]);
   });
 
   it('should not include phrases in richWords', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'drip', pos: 'noun' },
-          { word: 'go hard', pos: 'verb' },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', pos: 'noun' },
+        { word: 'go hard', pos: 'verb' },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(1);
     expect(result.richWords[0]?.word).toBe('drip');
   });
 
   it('should keep richWords in same sorted order as words', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'zap', frequency: 1 },
-          { word: 'ace', frequency: 99 },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'zap', frequency: 1 },
+        { word: 'ace', frequency: 99 },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.words).toEqual(['ace', 'zap']);
     expect(result.richWords.map((rw) => rw.word)).toEqual(['ace', 'zap']);
   });
 
-  it('should collect bars from files and deduplicate by text', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'KOHH',
-        grains: [],
-        bars: [
-          { text: 'line one', source: { artist: 'KOHH', track: 'Track A' } },
-          { text: 'line two' },
-        ],
-      },
-      {
-        name: 'Other',
-        grains: [],
-        bars: [
-          { text: 'line one', source: { artist: 'KOHH', track: 'Track B' } },
-          { text: 'line three' },
-        ],
-      },
-    ];
+  it('should include bars from the file', () => {
+    const file: WordgrainFile = {
+      name: 'KOHH',
+      grains: [],
+      bars: [
+        { text: 'line one', source: { artist: 'KOHH', track: 'Track A' } },
+        { text: 'line two' },
+      ],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
-    expect(result.bars).toHaveLength(3);
-    expect(result.bars.map((b) => b.text)).toEqual(['line one', 'line two', 'line three']);
+    expect(result.bars).toHaveLength(2);
+    expect(result.bars.map((b) => b.text)).toEqual(['line one', 'line two']);
     expect(result.bars[0]?.source?.track).toBe('Track A');
   });
 
   it('should preserve sentiment in richWords from grain data', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          { word: 'chill', sentiment: 'positive', sentiment_score: 0.8 },
-          { word: 'annoying', sentiment: 'negative', sentiment_score: -1.0 },
-          { word: 'plain' },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'chill', sentiment: 'positive', sentiment_score: 0.8 },
+        { word: 'annoying', sentiment: 'negative', sentiment_score: -1.0 },
+        { word: 'plain' },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     expect(result.richWords).toHaveLength(3);
     const annoying = result.richWords.find((w) => w.word === 'annoying');
@@ -289,24 +269,22 @@ describe('extractVocabulary', () => {
   });
 
   it('should extract tfidf, collocations, categories, and isSlang into richWords', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [
-          {
-            word: 'drip',
-            tfidf: 0.85,
-            categories: ['style', 'fashion'],
-            collocations: ['ice', 'flex'],
-            is_slang: true,
-          },
-          { word: 'chill' },
-        ],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        {
+          word: 'drip',
+          tfidf: 0.85,
+          categories: ['style', 'fashion'],
+          collocations: ['ice', 'flex'],
+          is_slang: true,
+        },
+        { word: 'chill' },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
 
     const drip = result.richWords.find((w) => w.word === 'drip');
     expect(drip?.tfidf).toBe(0.85);
@@ -321,76 +299,43 @@ describe('extractVocabulary', () => {
     expect(chill?.isSlang).toBeUndefined();
   });
 
-  it('should merge tfidf keeping max value on duplicates', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'a',
-        grains: [{ word: 'drip', tfidf: 0.3 }],
-        bars: [],
-      },
-      {
-        name: 'b',
-        grains: [{ word: 'drip', tfidf: 0.8 }],
-        bars: [],
-      },
-    ];
+  it('should merge tfidf keeping max value on duplicate grains', () => {
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'drip', tfidf: 0.3 }, { word: 'drip', tfidf: 0.8 }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
     const drip = result.richWords.find((w) => w.word === 'drip');
     expect(drip?.tfidf).toBe(0.8);
   });
 
-  it('should merge collocations and categories deduplicating on duplicates', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'a',
-        grains: [{ word: 'drip', collocations: ['ice', 'flex'], categories: ['style'] }],
-        bars: [],
-      },
-      {
-        name: 'b',
-        grains: [{ word: 'drip', collocations: ['flex', 'sauce'], categories: ['style', 'slang'] }],
-        bars: [],
-      },
-    ];
+  it('should merge collocations and categories deduplicating on duplicate grains', () => {
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [
+        { word: 'drip', collocations: ['ice', 'flex'], categories: ['style'] },
+        { word: 'drip', collocations: ['flex', 'sauce'], categories: ['style', 'slang'] },
+      ],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
     const drip = result.richWords.find((w) => w.word === 'drip');
     expect(drip?.collocations).toEqual(['ice', 'flex', 'sauce']);
     expect(drip?.categories).toEqual(['style', 'slang']);
   });
 
   it('should OR isSlang across duplicate grains', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'a',
-        grains: [{ word: 'drip', is_slang: false }],
-        bars: [],
-      },
-      {
-        name: 'b',
-        grains: [{ word: 'drip', is_slang: true }],
-        bars: [],
-      },
-    ];
+    const file: WordgrainFile = {
+      name: 'test',
+      grains: [{ word: 'drip', is_slang: false }, { word: 'drip', is_slang: true }],
+      bars: [],
+    };
 
-    const result = extractVocabulary(files);
+    const result = extractVocabulary(file);
     const drip = result.richWords.find((w) => w.word === 'drip');
     expect(drip?.isSlang).toBe(true);
-  });
-
-  it('should skip bars with empty text', () => {
-    const files: WordgrainFile[] = [
-      {
-        name: 'test',
-        grains: [],
-        bars: [{ text: '' }, { text: '  ' }, { text: 'valid bar' }],
-      },
-    ];
-
-    const result = extractVocabulary(files);
-
-    expect(result.bars).toHaveLength(1);
-    expect(result.bars[0]?.text).toBe('valid bar');
   });
 });

--- a/src/services/wordgrain/VocabularyExtractor.test.ts
+++ b/src/services/wordgrain/VocabularyExtractor.test.ts
@@ -302,7 +302,10 @@ describe('extractVocabulary', () => {
   it('should merge tfidf keeping max value on duplicate grains', () => {
     const file: WordgrainFile = {
       name: 'test',
-      grains: [{ word: 'drip', tfidf: 0.3 }, { word: 'drip', tfidf: 0.8 }],
+      grains: [
+        { word: 'drip', tfidf: 0.3 },
+        { word: 'drip', tfidf: 0.8 },
+      ],
       bars: [],
     };
 
@@ -330,7 +333,10 @@ describe('extractVocabulary', () => {
   it('should OR isSlang across duplicate grains', () => {
     const file: WordgrainFile = {
       name: 'test',
-      grains: [{ word: 'drip', is_slang: false }, { word: 'drip', is_slang: true }],
+      grains: [
+        { word: 'drip', is_slang: false },
+        { word: 'drip', is_slang: true },
+      ],
       bars: [],
     };
 

--- a/src/services/wordgrain/VocabularyExtractor.ts
+++ b/src/services/wordgrain/VocabularyExtractor.ts
@@ -2,7 +2,6 @@
  * Extract vocabulary from wordgrain files
  */
 import type {
-  Bar,
   Grain,
   GrainPos,
   VocabularySet,
@@ -110,31 +109,18 @@ function buildRichWords(
 }
 
 /**
- * Extract a deduplicated, sorted VocabularySet from wordgrain files
- * @param files - Array of parsed WordgrainFile objects
- * @returns Consolidated vocabulary set
+ * Extract a deduplicated, sorted VocabularySet from a wordgrain file
+ * @param file - Parsed WordgrainFile object
+ * @returns Vocabulary set
  */
-export function extractVocabulary(files: WordgrainFile[]): VocabularySet {
+export function extractVocabulary(file: WordgrainFile): VocabularySet {
   const wordSet = new Set<string>();
   const phraseSet = new Set<string>();
   const tagSet = new Set<string>();
-  const sources: string[] = [];
   const wordMetaMap = new Map<string, WordMeta>();
-  const barTextSet = new Set<string>();
-  const bars: Bar[] = [];
 
-  for (const file of files) {
-    sources.push(file.name);
-    for (const grain of file.grains) {
-      processGrain(grain, wordSet, phraseSet, tagSet, wordMetaMap);
-    }
-    for (const bar of file.bars) {
-      const trimmed = bar.text.trim();
-      if (trimmed && !barTextSet.has(trimmed)) {
-        barTextSet.add(trimmed);
-        bars.push(bar);
-      }
-    }
+  for (const grain of file.grains) {
+    processGrain(grain, wordSet, phraseSet, tagSet, wordMetaMap);
   }
 
   const sortedWords = [...wordSet].sort();
@@ -143,8 +129,8 @@ export function extractVocabulary(files: WordgrainFile[]): VocabularySet {
     words: sortedWords,
     phrases: [...phraseSet].sort(),
     tags: [...tagSet].sort(),
-    source: sources.join(', '),
+    source: file.name,
     richWords: buildRichWords(sortedWords, wordMetaMap),
-    bars,
+    bars: file.bars,
   };
 }

--- a/src/services/wordgrain/VocabularyExtractor.ts
+++ b/src/services/wordgrain/VocabularyExtractor.ts
@@ -1,13 +1,7 @@
 /**
  * Extract vocabulary from wordgrain files
  */
-import type {
-  Grain,
-  GrainPos,
-  VocabularySet,
-  VocabularyWord,
-  WordgrainFile,
-} from './types.js';
+import type { Grain, GrainPos, VocabularySet, VocabularyWord, WordgrainFile } from './types.js';
 
 interface WordMeta {
   pos?: GrainPos;

--- a/src/services/wordgrain/WordgrainLoader.test.ts
+++ b/src/services/wordgrain/WordgrainLoader.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { loadWordgrainFiles, parseWordgrainFile } from './WordgrainLoader.js';
+import { parseWordgrainFile } from './WordgrainLoader.js';
 
 describe('parseWordgrainFile', () => {
   let tmpDir: string;
@@ -637,54 +637,3 @@ describe('parseWordgrainFile', () => {
   });
 });
 
-describe('loadWordgrainFiles', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-load-test-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  it('should load valid .wg.json files from paths', () => {
-    const fileA = path.join(tmpDir, 'a.wg.json');
-    const fileB = path.join(tmpDir, 'b.wg.json');
-    fs.writeFileSync(fileA, JSON.stringify({ name: 'rapper-a', grains: [{ word: 'flex' }] }));
-    fs.writeFileSync(fileB, JSON.stringify({ name: 'rapper-b', grains: [{ word: 'bars' }] }));
-
-    const result = loadWordgrainFiles([fileA, fileB]);
-
-    expect(result).toHaveLength(2);
-    const names = result.map((f) => f.name).sort();
-    expect(names).toEqual(['rapper-a', 'rapper-b']);
-  });
-
-  it('should return empty array for empty paths list', () => {
-    const result = loadWordgrainFiles([]);
-    expect(result).toEqual([]);
-  });
-
-  it('should skip non-existent files', () => {
-    const validFile = path.join(tmpDir, 'valid.wg.json');
-    fs.writeFileSync(validFile, JSON.stringify({ name: 'valid', grains: [{ word: 'fire' }] }));
-
-    const result = loadWordgrainFiles(['/nonexistent/path.wg.json', validFile]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('valid');
-  });
-
-  it('should skip malformed files', () => {
-    const badFile = path.join(tmpDir, 'bad.wg.json');
-    const goodFile = path.join(tmpDir, 'good.wg.json');
-    fs.writeFileSync(badFile, '{ invalid json }');
-    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'fire' }] }));
-
-    const result = loadWordgrainFiles([badFile, goodFile]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('valid');
-  });
-});

--- a/src/services/wordgrain/WordgrainLoader.test.ts
+++ b/src/services/wordgrain/WordgrainLoader.test.ts
@@ -636,4 +636,3 @@ describe('parseWordgrainFile', () => {
     expect(result?.bars[1]?.text).toBe('also valid');
   });
 });
-

--- a/src/services/wordgrain/WordgrainLoader.ts
+++ b/src/services/wordgrain/WordgrainLoader.ts
@@ -152,24 +152,3 @@ export function parseWordgrainFile(filePath: string): WordgrainFile | null {
   }
 }
 
-/**
- * Load wordgrain files from individual file paths
- * @param filePaths - Array of paths to .wg.json files
- * @returns Array of parsed WordgrainFile objects
- */
-export function loadWordgrainFiles(filePaths: string[]): WordgrainFile[] {
-  const results: WordgrainFile[] = [];
-
-  for (const filePath of filePaths) {
-    try {
-      const parsed = parseWordgrainFile(filePath);
-      if (parsed) {
-        results.push(parsed);
-      }
-    } catch {
-      // Skip files that can't be read
-    }
-  }
-
-  return results;
-}

--- a/src/services/wordgrain/WordgrainLoader.ts
+++ b/src/services/wordgrain/WordgrainLoader.ts
@@ -151,4 +151,3 @@ export function parseWordgrainFile(filePath: string): WordgrainFile | null {
     return null;
   }
 }
-

--- a/src/services/wordgrain/WordgrainManager.test.ts
+++ b/src/services/wordgrain/WordgrainManager.test.ts
@@ -3,12 +3,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  getWordgrainFileInfo,
   getWordgrainStats,
-  listWordgrainFiles,
-  registerWordgrainFile,
+  validateWordgrainFile,
 } from './WordgrainManager.js';
 
-describe('listWordgrainFiles', () => {
+describe('getWordgrainFileInfo', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -19,11 +19,11 @@ describe('listWordgrainFiles', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should return empty array for empty paths list', () => {
-    expect(listWordgrainFiles([])).toEqual([]);
+  it('should return null for non-existent file', () => {
+    expect(getWordgrainFileInfo('/nonexistent/bad.wg.json')).toBeNull();
   });
 
-  it('should list valid .wg.json files with metadata', () => {
+  it('should return file info for valid .wg.json file', () => {
     const filePath = path.join(tmpDir, 'test.wg.json');
     fs.writeFileSync(
       filePath,
@@ -33,10 +33,9 @@ describe('listWordgrainFiles', () => {
       }),
     );
 
-    const result = listWordgrainFiles([filePath]);
+    const result = getWordgrainFileInfo(filePath);
 
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+    expect(result).toEqual({
       filename: 'test.wg.json',
       name: 'test-vocab',
       grainCount: 2,
@@ -45,43 +44,34 @@ describe('listWordgrainFiles', () => {
     });
   });
 
-  it('should sort files alphabetically by filename', () => {
-    const fileB = path.join(tmpDir, 'b.wg.json');
-    const fileA = path.join(tmpDir, 'a.wg.json');
-    fs.writeFileSync(fileB, JSON.stringify({ name: 'beta', grains: [{ word: 'b' }] }));
-    fs.writeFileSync(fileA, JSON.stringify({ name: 'alpha', grains: [{ word: 'a' }] }));
-
-    const result = listWordgrainFiles([fileB, fileA]);
-
-    expect(result).toHaveLength(2);
-    expect(result[0]?.filename).toBe('a.wg.json');
-    expect(result[1]?.filename).toBe('b.wg.json');
-  });
-
-  it('should skip non-existent files', () => {
-    const goodFile = path.join(tmpDir, 'good.wg.json');
-    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
-
-    const result = listWordgrainFiles(['/nonexistent/bad.wg.json', goodFile]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('valid');
-  });
-
-  it('should skip malformed files', () => {
+  it('should return null for malformed file', () => {
     const badFile = path.join(tmpDir, 'bad.wg.json');
-    const goodFile = path.join(tmpDir, 'good.wg.json');
     fs.writeFileSync(badFile, '{ invalid }');
-    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
 
-    const result = listWordgrainFiles([badFile, goodFile]);
+    expect(getWordgrainFileInfo(badFile)).toBeNull();
+  });
 
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe('valid');
+  it('should return bar count for bar-type file', () => {
+    const barFile = path.join(tmpDir, 'bar.wg.json');
+    fs.writeFileSync(
+      barFile,
+      JSON.stringify({
+        type: 'bar',
+        meta: { artist: 'Test' },
+        grains: [{ text: 'a bar' }],
+      }),
+    );
+
+    const result = getWordgrainFileInfo(barFile);
+
+    expect(result).not.toBeNull();
+    expect(result?.barCount).toBe(1);
+    expect(result?.grainCount).toBe(0);
+    expect(result?.type).toBe('bar');
   });
 });
 
-describe('registerWordgrainFile', () => {
+describe('validateWordgrainFile', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -96,13 +86,13 @@ describe('registerWordgrainFile', () => {
     const filePath = path.join(tmpDir, 'source.wg.json');
     fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
 
-    const result = registerWordgrainFile(filePath, []);
+    const result = validateWordgrainFile(filePath);
 
     expect(result).toEqual({ success: true });
   });
 
   it('should reject non-existent file', () => {
-    const result = registerWordgrainFile('/nonexistent/file.wg.json', []);
+    const result = validateWordgrainFile('/nonexistent/file.wg.json');
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('File does not exist');
@@ -112,7 +102,7 @@ describe('registerWordgrainFile', () => {
     const dirPath = path.join(tmpDir, 'subdir.wg.json');
     fs.mkdirSync(dirPath);
 
-    const result = registerWordgrainFile(dirPath, []);
+    const result = validateWordgrainFile(dirPath);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Path is not a file');
@@ -122,7 +112,7 @@ describe('registerWordgrainFile', () => {
     const filePath = path.join(tmpDir, 'source.json');
     fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
 
-    const result = registerWordgrainFile(filePath, []);
+    const result = validateWordgrainFile(filePath);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('File must have .wg.json extension');
@@ -132,32 +122,10 @@ describe('registerWordgrainFile', () => {
     const filePath = path.join(tmpDir, 'bad.wg.json');
     fs.writeFileSync(filePath, '{ "not": "valid" }');
 
-    const result = registerWordgrainFile(filePath, []);
+    const result = validateWordgrainFile(filePath);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Invalid wordgrain file format');
-  });
-
-  it('should reject already registered file', () => {
-    const filePath = path.join(tmpDir, 'dup.wg.json');
-    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
-
-    const result = registerWordgrainFile(filePath, [filePath]);
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('File is already registered');
-  });
-
-  it('should detect duplicate registration by resolved path', () => {
-    const filePath = path.join(tmpDir, 'dup.wg.json');
-    fs.writeFileSync(filePath, JSON.stringify({ name: 'test', grains: [{ word: 'hello' }] }));
-    // Use a relative-looking path that resolves to the same file
-    const existingPath = path.resolve(filePath);
-
-    const result = registerWordgrainFile(filePath, [existingPath]);
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('File is already registered');
   });
 });
 
@@ -172,11 +140,10 @@ describe('getWordgrainStats', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should return empty stats for empty paths list', () => {
-    const stats = getWordgrainStats([]);
+  it('should return empty stats for non-existent file', () => {
+    const stats = getWordgrainStats('/nonexistent/path.wg.json');
 
     expect(stats).toEqual({
-      totalFiles: 0,
       totalGrains: 0,
       wordCount: 0,
       phraseCount: 0,
@@ -185,71 +152,34 @@ describe('getWordgrainStats', () => {
     });
   });
 
-  it('should return empty stats for non-existent files', () => {
-    const stats = getWordgrainStats(['/nonexistent/path.wg.json']);
-
-    expect(stats).toEqual({
-      totalFiles: 0,
-      totalGrains: 0,
-      wordCount: 0,
-      phraseCount: 0,
-      tagCount: 0,
-      barCount: 0,
-    });
-  });
-
-  it('should compute aggregate stats across files', () => {
-    const fileA = path.join(tmpDir, 'a.wg.json');
-    const fileB = path.join(tmpDir, 'b.wg.json');
+  it('should compute stats for a single file', () => {
+    const filePath = path.join(tmpDir, 'a.wg.json');
     fs.writeFileSync(
-      fileA,
+      filePath,
       JSON.stringify({
         name: 'vocab-a',
         grains: [
           { word: 'hello', tags: ['greeting'] },
           { word: 'good morning', tags: ['greeting', 'formal'] },
-        ],
-      }),
-    );
-    fs.writeFileSync(
-      fileB,
-      JSON.stringify({
-        name: 'vocab-b',
-        grains: [
           { word: 'world', tags: ['noun'] },
-          { word: 'hello' }, // duplicate word
         ],
       }),
     );
 
-    const stats = getWordgrainStats([fileA, fileB]);
+    const stats = getWordgrainStats(filePath);
 
-    expect(stats.totalFiles).toBe(2);
-    expect(stats.totalGrains).toBe(4);
-    expect(stats.wordCount).toBe(2); // hello, world (deduplicated)
+    expect(stats.totalGrains).toBe(3);
+    expect(stats.wordCount).toBe(2); // hello, world
     expect(stats.phraseCount).toBe(1); // "good morning"
     expect(stats.tagCount).toBe(3); // greeting, formal, noun
-  });
-
-  it('should skip malformed files', () => {
-    const badFile = path.join(tmpDir, 'bad.wg.json');
-    const goodFile = path.join(tmpDir, 'good.wg.json');
-    fs.writeFileSync(badFile, '{ invalid }');
-    fs.writeFileSync(goodFile, JSON.stringify({ name: 'valid', grains: [{ word: 'ok' }] }));
-
-    const stats = getWordgrainStats([badFile, goodFile]);
-
-    expect(stats.totalFiles).toBe(1);
-    expect(stats.totalGrains).toBe(1);
   });
 
   it('should handle empty grains in stats', () => {
     const emptyFile = path.join(tmpDir, 'empty.wg.json');
     fs.writeFileSync(emptyFile, JSON.stringify({ name: 'empty', grains: [] }));
 
-    const stats = getWordgrainStats([emptyFile]);
+    const stats = getWordgrainStats(emptyFile);
 
-    expect(stats.totalFiles).toBe(1);
     expect(stats.totalGrains).toBe(0);
     expect(stats.wordCount).toBe(0);
   });
@@ -269,29 +199,9 @@ describe('getWordgrainStats', () => {
       }),
     );
 
-    const stats = getWordgrainStats([barFile]);
+    const stats = getWordgrainStats(barFile);
 
-    expect(stats.totalFiles).toBe(1);
     expect(stats.totalGrains).toBe(0);
     expect(stats.barCount).toBe(2);
-  });
-
-  it('should include bar count in file info', () => {
-    const barFile = path.join(tmpDir, 'bar.wg.json');
-    fs.writeFileSync(
-      barFile,
-      JSON.stringify({
-        type: 'bar',
-        meta: { artist: 'Test' },
-        grains: [{ text: 'a bar' }],
-      }),
-    );
-
-    const result = listWordgrainFiles([barFile]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.barCount).toBe(1);
-    expect(result[0]?.grainCount).toBe(0);
-    expect(result[0]?.type).toBe('bar');
   });
 });

--- a/src/services/wordgrain/WordgrainManager.ts
+++ b/src/services/wordgrain/WordgrainManager.ts
@@ -1,8 +1,8 @@
 /**
  * Wordgrain file management operations
  *
- * Manages individual file paths instead of a directory.
- * Files are referenced in-place and not copied.
+ * Manages a single wordgrain file path.
+ * The file is referenced in-place and not copied.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -17,7 +17,6 @@ export interface WordgrainFileInfo {
 }
 
 export interface WordgrainStats {
-  totalFiles: number;
   totalGrains: number;
   wordCount: number;
   phraseCount: number;
@@ -26,38 +25,31 @@ export interface WordgrainStats {
 }
 
 /**
- * List registered wordgrain files with metadata
+ * Get metadata for a registered wordgrain file
  */
-export function listWordgrainFiles(filePaths: string[]): WordgrainFileInfo[] {
-  const results: WordgrainFileInfo[] = [];
+export function getWordgrainFileInfo(filePath: string): WordgrainFileInfo | null {
+  try {
+    const parsed = parseWordgrainFile(filePath);
+    if (!parsed) return null;
 
-  for (const filePath of filePaths) {
-    try {
-      const parsed = parseWordgrainFile(filePath);
-      if (parsed) {
-        results.push({
-          filename: path.basename(filePath),
-          name: parsed.name,
-          grainCount: parsed.grains.length,
-          barCount: parsed.bars.length,
-          type: parsed.type,
-        });
-      }
-    } catch {
-      // Skip files that can't be read
-    }
+    return {
+      filename: path.basename(filePath),
+      name: parsed.name,
+      grainCount: parsed.grains.length,
+      barCount: parsed.bars.length,
+      type: parsed.type,
+    };
+  } catch {
+    return null;
   }
-
-  return results.sort((a, b) => a.filename.localeCompare(b.filename));
 }
 
 /**
  * Validate a file path for registration as a wordgrain file.
  * Does not copy the file; only checks existence and format.
  */
-export function registerWordgrainFile(
+export function validateWordgrainFile(
   filePath: string,
-  existingPaths: string[],
 ): { success: boolean; error?: string } {
   try {
     if (!fs.existsSync(filePath)) {
@@ -78,12 +70,6 @@ export function registerWordgrainFile(
       return { success: false, error: 'Invalid wordgrain file format' };
     }
 
-    // Check for duplicate registration
-    const resolved = path.resolve(filePath);
-    if (existingPaths.some((p) => path.resolve(p) === resolved)) {
-      return { success: false, error: 'File is already registered' };
-    }
-
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
@@ -92,11 +78,10 @@ export function registerWordgrainFile(
 }
 
 /**
- * Compute aggregate statistics for registered wordgrain files
+ * Compute statistics for a wordgrain file
  */
-export function getWordgrainStats(filePaths: string[]): WordgrainStats {
+export function getWordgrainStats(filePath: string): WordgrainStats {
   const empty: WordgrainStats = {
-    totalFiles: 0,
     totalGrains: 0,
     wordCount: 0,
     phraseCount: 0,
@@ -105,47 +90,37 @@ export function getWordgrainStats(filePaths: string[]): WordgrainStats {
   };
 
   try {
-    let totalFiles = 0;
-    let totalGrains = 0;
-    let totalBars = 0;
+    const parsed = parseWordgrainFile(filePath);
+    if (!parsed) return empty;
+
     const wordSet = new Set<string>();
     const phraseSet = new Set<string>();
     const tagSet = new Set<string>();
 
-    for (const filePath of filePaths) {
-      const parsed = parseWordgrainFile(filePath);
-      if (!parsed) continue;
+    for (const grain of parsed.grains) {
+      const trimmed = grain.word.trim();
+      if (!trimmed) continue;
 
-      totalFiles++;
-      totalGrains += parsed.grains.length;
-      totalBars += parsed.bars.length;
+      if (trimmed.includes(' ')) {
+        phraseSet.add(trimmed);
+      } else {
+        wordSet.add(trimmed);
+      }
 
-      for (const grain of parsed.grains) {
-        const trimmed = grain.word.trim();
-        if (!trimmed) continue;
-
-        if (trimmed.includes(' ')) {
-          phraseSet.add(trimmed);
-        } else {
-          wordSet.add(trimmed);
-        }
-
-        if (grain.tags) {
-          for (const tag of grain.tags) {
-            const trimmedTag = tag.trim();
-            if (trimmedTag) tagSet.add(trimmedTag);
-          }
+      if (grain.tags) {
+        for (const tag of grain.tags) {
+          const trimmedTag = tag.trim();
+          if (trimmedTag) tagSet.add(trimmedTag);
         }
       }
     }
 
     return {
-      totalFiles,
-      totalGrains,
+      totalGrains: parsed.grains.length,
       wordCount: wordSet.size,
       phraseCount: phraseSet.size,
       tagCount: tagSet.size,
-      barCount: totalBars,
+      barCount: parsed.bars.length,
     };
   } catch {
     return empty;

--- a/src/services/wordgrain/WordgrainManager.ts
+++ b/src/services/wordgrain/WordgrainManager.ts
@@ -48,9 +48,7 @@ export function getWordgrainFileInfo(filePath: string): WordgrainFileInfo | null
  * Validate a file path for registration as a wordgrain file.
  * Does not copy the file; only checks existence and format.
  */
-export function validateWordgrainFile(
-  filePath: string,
-): { success: boolean; error?: string } {
+export function validateWordgrainFile(filePath: string): { success: boolean; error?: string } {
   try {
     if (!fs.existsSync(filePath)) {
       return { success: false, error: 'File does not exist' };

--- a/src/services/wordgrain/index.test.ts
+++ b/src/services/wordgrain/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('./WordgrainLoader.js', () => ({
-  loadWordgrainFiles: vi.fn(),
+  parseWordgrainFile: vi.fn(),
 }));
 
 vi.mock('./VocabularyExtractor.js', () => ({
@@ -9,47 +9,47 @@ vi.mock('./VocabularyExtractor.js', () => ({
 }));
 
 import { extractVocabulary } from './VocabularyExtractor.js';
-import { loadWordgrainFiles } from './WordgrainLoader.js';
+import { parseWordgrainFile } from './WordgrainLoader.js';
 import { loadVocabulary } from './index.js';
 
-const mockLoadFiles = vi.mocked(loadWordgrainFiles);
+const mockParseFile = vi.mocked(parseWordgrainFile);
 const mockExtract = vi.mocked(extractVocabulary);
 
 describe('loadVocabulary', () => {
-  it('should return null when no valid files loaded', () => {
-    mockLoadFiles.mockReturnValue([]);
-    expect(loadVocabulary(['/path/test.wg.json'])).toBeNull();
+  it('should return null when file is invalid', () => {
+    mockParseFile.mockReturnValue(null);
+    expect(loadVocabulary('/path/test.wg.json')).toBeNull();
     expect(mockExtract).not.toHaveBeenCalled();
   });
 
   it('should return null when vocabulary is empty', () => {
-    mockLoadFiles.mockReturnValue([{ type: 'vocabulary', grains: [], bars: [] }] as never);
+    mockParseFile.mockReturnValue({ type: 'vocabulary', grains: [], bars: [] } as never);
     mockExtract.mockReturnValue({ words: [], phrases: [], bars: [] });
 
-    expect(loadVocabulary(['/path/test.wg.json'])).toBeNull();
+    expect(loadVocabulary('/path/test.wg.json')).toBeNull();
   });
 
   it('should return vocabulary when words exist', () => {
     const vocab = { words: [{ word: 'test', pos: 'noun' }], phrases: [], bars: [] };
-    mockLoadFiles.mockReturnValue([{ type: 'vocabulary', grains: [], bars: [] }] as never);
+    mockParseFile.mockReturnValue({ type: 'vocabulary', grains: [], bars: [] } as never);
     mockExtract.mockReturnValue(vocab as never);
 
-    expect(loadVocabulary(['/path/test.wg.json'])).toBe(vocab);
+    expect(loadVocabulary('/path/test.wg.json')).toBe(vocab);
   });
 
   it('should return vocabulary when phrases exist', () => {
     const vocab = { words: [], phrases: [{ phrase: 'hello world' }], bars: [] };
-    mockLoadFiles.mockReturnValue([{ type: 'vocabulary', grains: [], bars: [] }] as never);
+    mockParseFile.mockReturnValue({ type: 'vocabulary', grains: [], bars: [] } as never);
     mockExtract.mockReturnValue(vocab as never);
 
-    expect(loadVocabulary(['/path/test.wg.json'])).toBe(vocab);
+    expect(loadVocabulary('/path/test.wg.json')).toBe(vocab);
   });
 
   it('should return vocabulary when bars exist', () => {
     const vocab = { words: [], phrases: [], bars: [{ text: '|' }] };
-    mockLoadFiles.mockReturnValue([{ type: 'vocabulary', grains: [], bars: [] }] as never);
+    mockParseFile.mockReturnValue({ type: 'vocabulary', grains: [], bars: [] } as never);
     mockExtract.mockReturnValue(vocab as never);
 
-    expect(loadVocabulary(['/path/test.wg.json'])).toBe(vocab);
+    expect(loadVocabulary('/path/test.wg.json')).toBe(vocab);
   });
 });

--- a/src/services/wordgrain/index.ts
+++ b/src/services/wordgrain/index.ts
@@ -12,28 +12,28 @@ export type {
   WordgrainType,
 } from './types.js';
 export { extractVocabulary } from './VocabularyExtractor.js';
-export { loadWordgrainFiles, parseWordgrainFile } from './WordgrainLoader.js';
+export { parseWordgrainFile } from './WordgrainLoader.js';
 export type { WordgrainFileInfo, WordgrainStats } from './WordgrainManager.js';
 export {
+  getWordgrainFileInfo,
   getWordgrainStats,
-  listWordgrainFiles,
-  registerWordgrainFile,
+  validateWordgrainFile,
 } from './WordgrainManager.js';
 
 import { extractVocabulary } from './VocabularyExtractor.js';
-import { loadWordgrainFiles } from './WordgrainLoader.js';
+import { parseWordgrainFile } from './WordgrainLoader.js';
 import type { VocabularySet } from './types.js';
 
 /**
- * Load vocabulary from individual .wg.json file paths
- * @param filePaths - Array of paths to .wg.json files
- * @returns VocabularySet or null if no valid files or vocabulary is empty
+ * Load vocabulary from a .wg.json file
+ * @param filePath - Path to .wg.json file
+ * @returns VocabularySet or null if file is invalid or vocabulary is empty
  */
-export function loadVocabulary(filePaths: string[]): VocabularySet | null {
-  const files = loadWordgrainFiles(filePaths);
-  if (files.length === 0) return null;
+export function loadVocabulary(filePath: string): VocabularySet | null {
+  const file = parseWordgrainFile(filePath);
+  if (!file) return null;
 
-  const vocabulary = extractVocabulary(files);
+  const vocabulary = extractVocabulary(file);
   if (
     vocabulary.words.length === 0 &&
     vocabulary.phrases.length === 0 &&

--- a/src/ui/components/config/AddFileView.tsx
+++ b/src/ui/components/config/AddFileView.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useConfig } from '../../context/ConfigContext.js';
 
 export function AddFileView() {
-  const { addFile, setSubMode, error, clearError } = useConfig();
+  const { setFile, setSubMode, error, clearError } = useConfig();
   const [inputPath, setInputPath] = useState('');
 
   useInput((input, key) => {
@@ -16,7 +16,7 @@ export function AddFileView() {
     if (key.return) {
       const trimmed = inputPath.trim();
       if (trimmed) {
-        addFile(trimmed);
+        setFile(trimmed);
       }
       return;
     }
@@ -35,7 +35,7 @@ export function AddFileView() {
     <Box flexDirection="column">
       <Box marginBottom={1}>
         <Text bold color="green">
-          Add Wordgrain File
+          Set Wordgrain File
         </Text>
       </Box>
 
@@ -51,7 +51,7 @@ export function AddFileView() {
       )}
 
       <Box marginTop={1}>
-        <Text dimColor>Enter: add | Esc: cancel</Text>
+        <Text dimColor>Enter: set | Esc: cancel</Text>
       </Box>
     </Box>
   );

--- a/src/ui/components/config/ConfigView.tsx
+++ b/src/ui/components/config/ConfigView.tsx
@@ -11,18 +11,20 @@ import { WordgrainSection } from './WordgrainSection.js';
 export function ConfigView() {
   const { switchToList } = useNavigation();
   const {
-    files,
-    selectedFileIndex,
-    setSelectedFileIndex,
+    file,
+    selectedIndex,
+    setSelectedIndex,
     subMode,
     setSubMode,
-    reloadFiles,
+    reloadFile,
     toggleFeature,
   } = useConfig();
 
-  const totalItems = files.length + FEATURE_KEYS.length;
-  const isFeatureSelected = selectedFileIndex >= files.length;
-  const featureIndex = selectedFileIndex - files.length;
+  // Items: wordgrain file (1 if set, 0 if not) + feature keys
+  const fileItemCount = file ? 1 : 0;
+  const totalItems = fileItemCount + FEATURE_KEYS.length;
+  const isFeatureSelected = selectedIndex >= fileItemCount;
+  const featureIndex = selectedIndex - fileItemCount;
 
   useInput(
     (input, key) => {
@@ -33,14 +35,14 @@ export function ConfigView() {
 
       if (input === 'j' || key.downArrow) {
         if (totalItems > 0) {
-          setSelectedFileIndex(Math.min(selectedFileIndex + 1, totalItems - 1));
+          setSelectedIndex(Math.min(selectedIndex + 1, totalItems - 1));
         }
         return;
       }
 
       if (input === 'k' || key.upArrow) {
         if (totalItems > 0) {
-          setSelectedFileIndex(Math.max(selectedFileIndex - 1, 0));
+          setSelectedIndex(Math.max(selectedIndex - 1, 0));
         }
         return;
       }
@@ -50,13 +52,13 @@ export function ConfigView() {
         return;
       }
 
-      if (input === 'd' && !isFeatureSelected && files.length > 0) {
+      if (input === 'd' && !isFeatureSelected && file) {
         setSubMode('delete-confirm');
         return;
       }
 
       if (input === 'r') {
-        reloadFiles();
+        reloadFile();
         return;
       }
 

--- a/src/ui/components/config/ConfigView.tsx
+++ b/src/ui/components/config/ConfigView.tsx
@@ -10,15 +10,8 @@ import { WordgrainSection } from './WordgrainSection.js';
 
 export function ConfigView() {
   const { switchToList } = useNavigation();
-  const {
-    file,
-    selectedIndex,
-    setSelectedIndex,
-    subMode,
-    setSubMode,
-    reloadFile,
-    toggleFeature,
-  } = useConfig();
+  const { file, selectedIndex, setSelectedIndex, subMode, setSubMode, reloadFile, toggleFeature } =
+    useConfig();
 
   // Items: wordgrain file (1 if set, 0 if not) + feature keys
   const fileItemCount = file ? 1 : 0;

--- a/src/ui/components/config/DeleteConfirm.tsx
+++ b/src/ui/components/config/DeleteConfirm.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import { useConfig } from '../../context/ConfigContext.js';
 
 export function DeleteConfirm() {
-  const { files, selectedFileIndex, removeFile, setSubMode } = useConfig();
-  const file = files[selectedFileIndex];
+  const { file, clearFile, setSubMode } = useConfig();
 
   useInput((input, key) => {
     if (input === 'y' && file) {
-      removeFile(file.filename);
+      clearFile();
       return;
     }
 

--- a/src/ui/components/config/WordgrainSection.tsx
+++ b/src/ui/components/config/WordgrainSection.tsx
@@ -21,9 +21,7 @@ export function WordgrainSection() {
       ) : (
         <Box flexDirection="column" paddingLeft={2}>
           <Text>
-            <Text color={isSelected ? 'cyan' : undefined}>
-              {isSelected ? '> ' : '  '}
-            </Text>
+            <Text color={isSelected ? 'cyan' : undefined}>{isSelected ? '> ' : '  '}</Text>
             <Text bold={isSelected}>{file.name}</Text>
             <Text dimColor>
               {' '}
@@ -39,8 +37,8 @@ export function WordgrainSection() {
 
           <Box marginTop={1} paddingLeft={2}>
             <Text dimColor>
-              {stats.totalGrains} grains ({stats.wordCount} words,{' '}
-              {stats.phraseCount} phrases, {stats.tagCount} tags)
+              {stats.totalGrains} grains ({stats.wordCount} words, {stats.phraseCount} phrases,{' '}
+              {stats.tagCount} tags)
               {stats.barCount > 0 ? `, ${stats.barCount} bars` : ''}
             </Text>
           </Box>

--- a/src/ui/components/config/WordgrainSection.tsx
+++ b/src/ui/components/config/WordgrainSection.tsx
@@ -3,50 +3,47 @@ import React from 'react';
 import { useConfig } from '../../context/ConfigContext.js';
 
 export function WordgrainSection() {
-  const { files, stats, selectedFileIndex } = useConfig();
+  const { file, stats, selectedIndex } = useConfig();
+  const isSelected = selectedIndex === 0;
 
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
         <Text bold color="yellow">
-          Wordgrain Files
+          Wordgrain File
         </Text>
       </Box>
 
-      {files.length === 0 ? (
+      {!file ? (
         <Box paddingLeft={2}>
-          <Text dimColor>No wordgrain files registered. Press &apos;a&apos; to add.</Text>
+          <Text dimColor>No wordgrain file set. Press &apos;a&apos; to set.</Text>
         </Box>
       ) : (
         <Box flexDirection="column" paddingLeft={2}>
-          {files.map((file, index) => (
-            <Text key={file.filename}>
-              <Text color={index === selectedFileIndex ? 'cyan' : undefined}>
-                {index === selectedFileIndex ? '> ' : '  '}
-              </Text>
-              <Text bold={index === selectedFileIndex}>{file.name}</Text>
-              <Text dimColor>
-                {' '}
-                ({file.filename},{' '}
-                {file.grainCount > 0 && file.barCount > 0
-                  ? `${file.grainCount} grains, ${file.barCount} bars`
-                  : file.barCount > 0
-                    ? `${file.barCount} bars`
-                    : `${file.grainCount} grains`}
-                )
-              </Text>
+          <Text>
+            <Text color={isSelected ? 'cyan' : undefined}>
+              {isSelected ? '> ' : '  '}
             </Text>
-          ))}
-        </Box>
-      )}
-
-      {files.length > 0 && (
-        <Box marginTop={1} paddingLeft={2}>
-          <Text dimColor>
-            Total: {stats.totalFiles} files, {stats.totalGrains} grains ({stats.wordCount} words,{' '}
-            {stats.phraseCount} phrases, {stats.tagCount} tags)
-            {stats.barCount > 0 ? `, ${stats.barCount} bars` : ''}
+            <Text bold={isSelected}>{file.name}</Text>
+            <Text dimColor>
+              {' '}
+              ({file.filename},{' '}
+              {file.grainCount > 0 && file.barCount > 0
+                ? `${file.grainCount} grains, ${file.barCount} bars`
+                : file.barCount > 0
+                  ? `${file.barCount} bars`
+                  : `${file.grainCount} grains`}
+              )
+            </Text>
           </Text>
+
+          <Box marginTop={1} paddingLeft={2}>
+            <Text dimColor>
+              {stats.totalGrains} grains ({stats.wordCount} words,{' '}
+              {stats.phraseCount} phrases, {stats.tagCount} tags)
+              {stats.barCount > 0 ? `, ${stats.barCount} bars` : ''}
+            </Text>
+          </Box>
         </Box>
       )}
     </Box>

--- a/src/ui/context/ConfigContext.tsx
+++ b/src/ui/context/ConfigContext.tsx
@@ -5,10 +5,10 @@ import type { MumblFeatures, ResolvedConfig } from '../../config/types.js';
 import {
   type WordgrainFileInfo,
   type WordgrainStats,
+  getWordgrainFileInfo,
   getWordgrainStats,
-  listWordgrainFiles,
   loadVocabulary,
-  registerWordgrainFile,
+  validateWordgrainFile,
 } from '../../services/wordgrain/index.js';
 import type { VocabularySet } from '../../services/wordgrain/types.js';
 import { useServices } from './ServiceContext.js';
@@ -17,17 +17,17 @@ export type ConfigSubMode = 'normal' | 'add-file' | 'delete-confirm';
 
 interface ConfigContextValue {
   config: ResolvedConfig;
-  files: WordgrainFileInfo[];
+  file: WordgrainFileInfo | null;
   stats: WordgrainStats;
-  selectedFileIndex: number;
-  setSelectedFileIndex: (index: number) => void;
+  selectedIndex: number;
+  setSelectedIndex: (index: number) => void;
   subMode: ConfigSubMode;
   setSubMode: (mode: ConfigSubMode) => void;
   error: string | null;
   clearError: () => void;
-  addFile: (sourcePath: string) => void;
-  removeFile: (filename: string) => void;
-  reloadFiles: () => void;
+  setFile: (sourcePath: string) => void;
+  clearFile: () => void;
+  reloadFile: () => void;
   features: MumblFeatures;
   toggleFeature: (key: keyof MumblFeatures) => void;
 }
@@ -48,7 +48,6 @@ interface ConfigProviderProps {
 }
 
 const emptyStats: WordgrainStats = {
-  totalFiles: 0,
   totalGrains: 0,
   wordCount: 0,
   phraseCount: 0,
@@ -67,77 +66,72 @@ const emptyVocabulary: VocabularySet = {
 
 export function ConfigProvider({ config, children }: ConfigProviderProps) {
   const { llmService, reactionService } = useServices();
-  const [wordgrainFiles, setWordgrainFiles] = useState<string[]>(config.wordgrainFiles ?? []);
-  const [files, setFiles] = useState<WordgrainFileInfo[]>([]);
+  const [wordgrainFile, setWordgrainFile] = useState<string | undefined>(config.wordgrainFile);
+  const [file, setFileInfo] = useState<WordgrainFileInfo | null>(null);
   const [stats, setStats] = useState<WordgrainStats>(emptyStats);
-  const [selectedFileIndex, setSelectedFileIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [subMode, setSubMode] = useState<ConfigSubMode>('normal');
   const [error, setError] = useState<string | null>(null);
   const [features, setFeatures] = useState<MumblFeatures>(config.features);
 
-  const refreshFiles = useCallback(() => {
-    if (wordgrainFiles.length === 0) {
-      setFiles([]);
+  const refreshFile = useCallback(() => {
+    if (!wordgrainFile) {
+      setFileInfo(null);
       setStats(emptyStats);
       return;
     }
-    setFiles(listWordgrainFiles(wordgrainFiles));
-    setStats(getWordgrainStats(wordgrainFiles));
-  }, [wordgrainFiles]);
+    setFileInfo(getWordgrainFileInfo(wordgrainFile));
+    setStats(getWordgrainStats(wordgrainFile));
+  }, [wordgrainFile]);
 
   const hotReload = useCallback(() => {
-    if (wordgrainFiles.length === 0) {
+    if (!wordgrainFile) {
       llmService.setVocabulary(emptyVocabulary);
       reactionService.setVocabulary(emptyVocabulary);
       return;
     }
-    const vocabulary = loadVocabulary(wordgrainFiles);
+    const vocabulary = loadVocabulary(wordgrainFile);
     llmService.setVocabulary(vocabulary ?? emptyVocabulary);
     reactionService.setVocabulary(vocabulary ?? emptyVocabulary);
-  }, [wordgrainFiles, llmService, reactionService]);
+  }, [wordgrainFile, llmService, reactionService]);
 
   useEffect(() => {
-    refreshFiles();
+    refreshFile();
     hotReload();
-  }, [refreshFiles, hotReload]);
+  }, [refreshFile, hotReload]);
 
   const clearError = useCallback(() => {
     setError(null);
   }, []);
 
-  const addFile = useCallback(
+  const setFile = useCallback(
     (sourcePath: string) => {
       const resolved = path.resolve(sourcePath);
-      const result = registerWordgrainFile(resolved, wordgrainFiles);
+      const result = validateWordgrainFile(resolved);
       if (!result.success) {
-        setError(result.error ?? 'Failed to add file');
+        setError(result.error ?? 'Failed to set file');
         return;
       }
-      const updated = [...wordgrainFiles, resolved];
-      setWordgrainFiles(updated);
-      saveConfigFile({ wordgrainFiles: updated });
+      setWordgrainFile(resolved);
+      saveConfigFile({ wordgrainFile: resolved });
       setError(null);
       setSubMode('normal');
     },
-    [wordgrainFiles],
+    [],
   );
 
-  const removeFile = useCallback(
-    (filename: string) => {
-      const updated = wordgrainFiles.filter((fp) => path.basename(fp) !== filename);
-      setWordgrainFiles(updated);
-      saveConfigFile({ wordgrainFiles: updated });
-      setError(null);
-      setSelectedFileIndex((prev) => Math.max(0, prev - 1));
-      setSubMode('normal');
-    },
-    [wordgrainFiles],
-  );
+  const clearFile = useCallback(() => {
+    setWordgrainFile(undefined);
+    saveConfigFile({ wordgrainFile: '' });
+    setError(null);
+    setSelectedIndex(0);
+    setSubMode('normal');
+  }, []);
 
-  const reloadFiles = useCallback(() => {
-    refreshFiles();
+  const reloadFile = useCallback(() => {
+    refreshFile();
     hotReload();
-  }, [refreshFiles, hotReload]);
+  }, [refreshFile, hotReload]);
 
   const toggleFeature = useCallback(
     (key: keyof MumblFeatures) => {
@@ -153,17 +147,17 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
     <ConfigContext.Provider
       value={{
         config,
-        files,
+        file,
         stats,
-        selectedFileIndex,
-        setSelectedFileIndex,
+        selectedIndex,
+        setSelectedIndex,
         subMode,
         setSubMode,
         error,
         clearError,
-        addFile,
-        removeFile,
-        reloadFiles,
+        setFile,
+        clearFile,
+        reloadFile,
         features,
         toggleFeature,
       }}

--- a/src/ui/context/ConfigContext.tsx
+++ b/src/ui/context/ConfigContext.tsx
@@ -104,21 +104,18 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
     setError(null);
   }, []);
 
-  const setFile = useCallback(
-    (sourcePath: string) => {
-      const resolved = path.resolve(sourcePath);
-      const result = validateWordgrainFile(resolved);
-      if (!result.success) {
-        setError(result.error ?? 'Failed to set file');
-        return;
-      }
-      setWordgrainFile(resolved);
-      saveConfigFile({ wordgrainFile: resolved });
-      setError(null);
-      setSubMode('normal');
-    },
-    [],
-  );
+  const setFile = useCallback((sourcePath: string) => {
+    const resolved = path.resolve(sourcePath);
+    const result = validateWordgrainFile(resolved);
+    if (!result.success) {
+      setError(result.error ?? 'Failed to set file');
+      return;
+    }
+    setWordgrainFile(resolved);
+    saveConfigFile({ wordgrainFile: resolved });
+    setError(null);
+    setSubMode('normal');
+  }, []);
 
   const clearFile = useCallback(() => {
     setWordgrainFile(undefined);


### PR DESCRIPTION
## Summary

Closes #226

Change `wordgrainFiles` (string array) to `wordgrainFile` (single string) across config, services, and UI. Multiple wordgrain files dilute the persona concept — one rapper's vocabulary per session.

- Config types: `wordgrainFiles?: string[]` → `wordgrainFile?: string`
- ConfigFile: read/write single file with migration from old array format (takes first element)
- WordgrainManager: single-file APIs (`getWordgrainFileInfo`, `validateWordgrainFile`, `getWordgrainStats`)
- VocabularyExtractor: accept single `WordgrainFile` instead of array, remove cross-file dedup
- Remove unused `loadWordgrainFiles` function
- UI: single file display, "Set/Clear" instead of "Add/Remove"

## Changes

- **src/config/types.ts**: `wordgrainFile?: string` in both `MumblConfig` and `ResolvedConfig`
- **src/config/ConfigFile.ts**: Migration logic reads old `wordgrainFiles` array, takes `[0]`, cleans up old key on save
- **src/config/ResolveConfig.ts**: Use `wordgrainFile`
- **src/services/wordgrain/**: Simplify all APIs to single-file, remove multi-file helpers
- **src/ui/**: Single file display and management in config screen
- **README.md**: Update config examples

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm ci:all` passes (type-check + lint + 967 tests)
- [x] Migration test: old `wordgrainFiles` array format correctly picks first element
- [x] New `wordgrainFile` format takes priority over old `wordgrainFiles` if both present
- [ ] Manual: verify config UI shows single file, set/clear workflow works